### PR TITLE
Use larger page size while validating k3s version

### DIFF
--- a/lib/hetzner/k3s/cli.rb
+++ b/lib/hetzner/k3s/cli.rb
@@ -198,7 +198,7 @@ module Hetzner
 
         def find_available_releases
           @available_releases ||= begin
-            response = HTTP.get("https://api.github.com/repos/k3s-io/k3s/tags").body
+            response = HTTP.get("https://api.github.com/repos/k3s-io/k3s/tags?per_page=999").body
             JSON.parse(response).map { |hash| hash["name"] }
           end
         rescue


### PR DESCRIPTION
First of all, thank you for your wonderful piece of software!

When I want to use an "older" release of k3s (eg.: 1.20.12 which was released two weeks ago) I get the following error:
```
Some information in the configuration file requires your attention:
 - Invalid k3s version
 ```

I find this part of the code:
https://github.com/vitobotta/hetzner-k3s/blob/f2154e59d7baaaedd16d506a2bc11b294e3b08f7/lib/hetzner/k3s/cli.rb#L201

It uses GitHub API to search for tags, but it will only send back the last 30 tags.

According to GH API [docs](https://docs.github.com/en/rest/reference/git#references), it's possible to increase the page size, using the `per_page` parameter.

So I raised this per_page limit to 999.