### PR TITLE
Remove Kubernetes 1.24 deprecated address argument for kube-controlle…

### DIFF
--- a/lib/hetzner/k3s/cluster.rb
+++ b/lib/hetzner/k3s/cluster.rb
@@ -211,10 +211,8 @@ class Cluster
         --cluster-cidr=10.244.0.0/16 \
         --etcd-expose-metrics=true \
         #{flannel_wireguard} \
-        --kube-controller-manager-arg="address=0.0.0.0" \
         --kube-controller-manager-arg="bind-address=0.0.0.0" \
         --kube-proxy-arg="metrics-bind-address=0.0.0.0" \
-        --kube-scheduler-arg="address=0.0.0.0" \
         --kube-scheduler-arg="bind-address=0.0.0.0" \
         #{taint} #{extra_args} \
         --kubelet-arg="cloud-provider=external" \


### PR DESCRIPTION
With these changes the create-cluster command will also work for Kubernetes v1.24+