### PR TITLE
Increase subnet mask to 24

### DIFF
--- a/lib/hetzner/infra/network.rb
+++ b/lib/hetzner/infra/network.rb
@@ -63,7 +63,7 @@ module Hetzner
         ip_range: '10.0.0.0/16',
         subnets: [
           {
-            ip_range: '10.0.0.0/16',
+            ip_range: '10.0.0.0/24',
             network_zone: (location == 'ash' ? 'us-east' : 'eu-central'),
             type: 'cloud'
           }


### PR DESCRIPTION
Increase of subnet mask to 24 would gives the possibility to add vSwitch to the network. Currently the network and only existing subnet have the same subnet mask and therefor any other subnet has an overlap and is denied.
With a vSwitch I could probably connect a dedicated server to the cloud.