### PR TITLE
Add missing brew dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before using the tool, be sure to have kubectl installed as it's required to ins
 #### With Homebrew
 
 ```bash
-brew install libssh2 libevent bdw-gc
+brew install libssh2 libevent bdw-gc libyaml
 brew install vitobotta/tap/hetzner_k3s
 ```
 


### PR DESCRIPTION
The dependency `libyaml` is missing in the README, resulting in such errors:

```
dyld[79096]: Library not loaded: /opt/homebrew/opt/libyaml/lib/libyaml-0.2.dylib
  Referenced from: <182D868F-ABE0-349D-A614-C31E254B37EC> /opt/homebrew/Cellar/hetzner_k3s/0.6.9/bin/hetzner-k3s
  Reason: tried: '/opt/homebrew/opt/libyaml/lib/libyaml-0.2.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/libyaml/lib/libyaml-0.2.dylib' (no such file), '/opt/homebrew/opt/libyaml/lib/libyaml-0.2.dylib' (no such file), '/usr/local/lib/libyaml-0.2.dylib' (no such file), '/usr/lib/libyaml-0.2.dylib' (no such file, not in dyld cache)
[1]    79096 abort      hetzner-k3s releases
```

This PR fixes the docs.

Probably an even better approach would be to add the dependencies to the brew formula (using `depends_on`).