### PR TITLE
Expand config path, allow for hetzner_token to come from a file

### DIFF
--- a/src/configuration/loader.cr
+++ b/src/configuration/loader.cr
@@ -124,7 +124,7 @@ class Configuration::Loader
   private def validate_allows_token_from_file
     if settings.hetzner_token.starts_with?("file://")
       if !allow_token_from_file
-        errors << "Hetzner token is set to a path but paths are not allowed, use --allow-token-from-file flag"
+        errors << "Hetzner token is set to a path but paths are not allowed; use --allow-token-from-file flag"
         return
       end
     end

--- a/src/configuration/loader.cr
+++ b/src/configuration/loader.cr
@@ -32,7 +32,7 @@ class Configuration::Loader
   getter settings : Configuration::Main
 
   getter hetzner_client : Hetzner::Client do
-    Hetzner::Client.new(settings.hetzner_token)
+    Hetzner::Client.new(settings.resolved_hetzner_token)
   end
 
   getter public_ssh_key_path do
@@ -80,9 +80,10 @@ class Configuration::Loader
   private property locations_loaded : Bool = false
 
   def initialize(@configuration_file_path, @new_k3s_version)
-    @settings = Configuration::Main.from_yaml(File.read(configuration_file_path))
+    expanded_path = Path[configuration_file_path].expand(home: true).to_s
+    @settings = Configuration::Main.from_yaml(File.read(expanded_path))
 
-    Settings::ConfigurationFilePath.new(errors, configuration_file_path).validate
+    Settings::ConfigurationFilePath.new(errors, expanded_path).validate
 
     print_errors unless errors.empty?
   end

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -30,4 +30,19 @@ class Configuration::Main
   getter existing_network : String?
   getter image : String = "ubuntu-22.04"
   getter snapshot_os : String = "default"
+
+  def resolved_hetzner_token : String
+    if hetzner_token.starts_with?("file://")
+      path = hetzner_token.lchop("file://")
+      path = Path[path].expand(home: true).to_s
+      if !File.exists?(path)
+        puts "Expected the #{path} token file to exist"
+        exit 1
+      end
+      puts "Resolved Hetzner token from #{path}"
+      return File.read(path).strip
+    end
+    return hetzner_token
+  end
+
 end

--- a/src/hetzner-k3s.cr
+++ b/src/hetzner-k3s.cr
@@ -19,8 +19,13 @@ module Hetzner::K3s
                   short: "c",
                   required: true
 
+      define_flag allow_token_from_file : Bool,
+                  description: "If set, allows using hetzner_token with file paths",
+                  long: "--allow-token-from-file",
+                  required: false
+
       def run
-        configuration = Configuration::Loader.new(flags.configuration_file_path, nil)
+        configuration = Configuration::Loader.new(flags.configuration_file_path, flags.allow_token_from_file, nil)
         configuration.validate(:create)
 
         Cluster::Create.new(configuration: configuration).run
@@ -36,8 +41,13 @@ module Hetzner::K3s
                   short: "c",
                   required: true
 
+      define_flag allow_token_from_file : Bool,
+                  description: "If set, allows using hetzner_token with file paths",
+                  long: "--allow-token-from-file",
+                  required: false
+
       def run
-        configuration = Configuration::Loader.new(flags.configuration_file_path, nil)
+        configuration = Configuration::Loader.new(flags.configuration_file_path, flags.allow_token_from_file, nil)
         configuration.validate(:delete)
 
         Cluster::Delete.new(configuration: configuration).run
@@ -53,13 +63,18 @@ module Hetzner::K3s
                   short: "c",
                   required: true
 
+      define_flag allow_token_from_file : Bool,
+                  description: "If set, allows using hetzner_token with file paths",
+                  long: "--allow-token-from-file",
+                  required: false
+
       define_flag new_k3s_version : String,
                   description: "The new version of k3s to upgrade to",
                   long: "--new-k3s-version",
                   required: true
 
       def run
-        configuration = Configuration::Loader.new(flags.configuration_file_path, flags.new_k3s_version)
+        configuration = Configuration::Loader.new(flags.configuration_file_path, flags.allow_token_from_file, flags.new_k3s_version)
         configuration.validate(:upgrade)
 
         Cluster::Upgrade.new(configuration: configuration).run

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -234,7 +234,7 @@ class Kubernetes::Installer
 
     secret_manifest = Crinja.render(HETZNER_CLOUD_SECRET_MANIFEST, {
       network: (settings.existing_network || settings.cluster_name),
-      token: settings.hetzner_token
+      token: settings.resolved_hetzner_token
     })
 
     command = <<-BASH


### PR DESCRIPTION
Hey @vitobotta. Thank you very much for this project. I was able to start a k8s cluster in Hetzner in no time. While working with the tool, I came across a couple of problems:

- The main config path needed to be expanded. Passing `--config=~/path/to/file.yaml` would fail with an unhandled exception. I am providing a fix here.
- The second problem is more profound: I imagine one would like to commit the `cluster yaml config` file into a repository. However, there are better ideas than having the Hetzner token in the repository. This PR adds very rudimentary support for loading the token from a file. Basically, in the yaml file:

```yaml
---
hetzner_token: file://~/.hetzner/token
...
```

If the `hetzner_token` key value starts with `file://`, the program strips the `file://` prefix, expands the remaining value, checks if the file exists, reads the content, and uses that value as a token.

To prevent unexpected token exfiltration when a downloaded yaml file is used by the unsuspecting user and the path points to a sensitive file, the user has to explicitly allow the use of such paths by passing `--allow-token-from-file` flag.

Example:

```sh
hetzner-k3s create --config=~/.hetzner/cluster.yaml --allow-token-file
```

And without the last flag:

```
Some information in the configuration file requires your attention:
  - Hetzner token is set to a path, but paths are not allowed; use --allow-token-from-file flag
```