### PR TITLE
Add configuration options for cluster-cidr, service-cidr and cluster-dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ api_allowed_networks:
 private_network_subnet: 10.0.0.0/16 # ensure this doesn't overlap with other networks in the same project
 disable_flannel: false # set to true if you want to install a different CNI
 schedule_workloads_on_masters: false
+# cluster_cidr: 10.244.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for pod IPs
+# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs
+# cluster_dns: 10.43.0.10 # optional: IPv4 Cluster IP for coredns service. Needs to be an address from the service_cidr range
 # enable_public_net_ipv4: false # default is true
 # enable_public_net_ipv6: false # default is true
 # image: rocky-9 # optional: default is ubuntu-22.04
@@ -457,7 +460,25 @@ Once the cluster is ready you can create persistent volumes out of the box with 
 
 ### Keeping a project per cluster
 
-I recommend that you create a separate Hetzner project for each cluster, because otherwise multiple clusters will attempt to create overlapping routes. I will make the pod cidr configurable in the future to avoid this, but I still recommend keeping clusters separated from each other. This way, if you want to delete a cluster with all the resources created for it, you can just delete the project.
+If you want to create multiple clusters per project, see [Configuring Cluster-CIDR and Service-CIDR](#configuring-cluster-cidr-and-service-cidr). Make sure, that every cluster has its own dedicated Cluster- and Service-CIDR. If they overlap, it will cause problems. But I still recommend keeping clusters separated from each other. This way, if you want to delete a cluster with all the resources created for it, you can just delete the project.
+
+### Configuring Cluster-CIDR and Service-CIDR
+
+Cluster-CIDR and Service-CIDR describe the IP-Ranges that are used for pods and services respectively. Unter normal circumstances you should not need to change these values. However, advanced scenarios may require you to change them to avoid networking conflicts.
+
+**Changing the Cluster-CIDR (Pod IP-Range):**
+
+To change the Cluster-CIDR, uncomment/add the `cluster_cidr` option in your cluster configuration file and provide a valid CIDR notated network to use. The provided network must not be a subnet of your private network.
+
+**Changing the Service-CIDR (Service IP-Range):**
+
+To change the Service-CIDR, uncomment/add the `service_cidr` option in your cluster configuration file and provide a valid CIDR notated network to use. The provided network must not be a subnet of your private network.
+
+Also uncomment the `cluster_dns` option and provide a single IP-Address from your `service_cidr` range. `cluster_dns` sets the IP-Address of the coredns service.
+
+**Sizing the Networks**
+
+The networks you provide should provide enough space for the expected amount of pods/services. By default `/16` networks are used. Please make sure you chose an adequate size, as changing the CIDR afterwards is not supported.
 
 
 

--- a/cluster_config.yaml.example
+++ b/cluster_config.yaml.example
@@ -13,6 +13,9 @@ api_allowed_networks:
   - 0.0.0.0/0
 schedule_workloads_on_masters: false
 private_network_subnet: 10.0.0.0/16
+# cluster_cidr: 10.244.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for pod IPs
+# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs
+# cluster_dns: 10.43.0.10 # optional: IPv4 Cluster IP for coredns service. Needs to be an address from the service_cidr range
 disable_flannel: false # set to true if you want to install a different CNI
 # enable_public_net_ipv4: false # default is true
 # enable_public_net_ipv6: false # default is true

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -35,6 +35,9 @@ class Configuration::Main
   getter autoscaling_image : String?
   getter snapshot_os : String = "default"
   getter private_network_subnet : String = "10.0.0.0/16"
+  getter cluster_cidr : String = "10.244.0.0/16"
+  getter service_cidr : String = "10.43.0.0/16"
+  getter cluster_dns : String = "10.43.0.10"
   getter cloud_controller_manager_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.18.0/deploy/ccm-networks.yaml"
   getter csi_driver_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml"
   getter system_upgrade_controller_manifest_url : String = "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml"

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -24,7 +24,9 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN
 --disable metrics-server \
 --write-kubeconfig-mode=644 \
 --node-name=$HOSTNAME \
---cluster-cidr=10.244.0.0/16 \
+--cluster-cidr={{ cluster_cidr }} \
+--service-cidr={{ service_cidr }} \
+--cluster-dns={{ cluster_dns }} \
 --etcd-expose-metrics=true \
 --kube-controller-manager-arg="bind-address=0.0.0.0" \
 --kube-proxy-arg="metrics-bind-address=0.0.0.0" \


### PR DESCRIPTION
This PR adds three new options to the configuration:

- `cluster_cidr`
- `service_cidr`
- `cluster_dns`

These three options are basically just passed on to the CLI command when setting up the master.

I have compiled and tested it with a small test cluster on Hetzner. Everything seems to work.

**Please note:** This is the first time that I work with Crystal. I haven't really heard of this language before I've seen this project. So if anything is wrong, please tell me so I can fix it (and learn).