### PR TITLE
Using server name to reduce return list. fixes vitobotta/hetzner-k3s#184

### DIFF
--- a/src/hetzner/client.cr
+++ b/src/hetzner/client.cr
@@ -31,7 +31,7 @@ class Hetzner::Client
   def get(path, params : Hash = {} of Symbol => String | Bool | Nil) : String
     response = Crest.get(
       "#{api_url}#{path}",
-      params,
+      params: params,
       json: true,
       headers: headers
     )

--- a/src/hetzner/server/find.cr
+++ b/src/hetzner/server/find.cr
@@ -10,8 +10,7 @@ class Hetzner::Server::Find
   end
 
   def run
-    servers = ServersList.from_json(hetzner_client.get("/servers")).servers
-
+    servers = ServersList.from_json(hetzner_client.get("/servers",{:name => server_name})).servers
     servers.find do |server|
       server.name == server_name
     end


### PR DESCRIPTION
Fixes return lists without the actual server when more than 25 entries.