### PR TITLE
Added arm fix with pinned version

### DIFF
--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -252,7 +252,7 @@ class Kubernetes::Installer
   private def deploy_csi_driver
     puts "\nDeploying Hetzner CSI Driver..."
 
-    command = "kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/master/deploy/kubernetes/hcloud-csi.yml"
+    command = "kubectl apply -f https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml"
 
     result = Util::Shell.run(command, configuration.kubeconfig_path, settings.hetzner_token)
 


### PR DESCRIPTION
I discovered a bug with the new arm servers, as the csi-driver docker image tagged with 'latest' is not compatible with arm. https://hub.docker.com/r/hetznercloud/hcloud-csi-driver/tags?page=1

I pinned the version to 2.3.2 which is compatible with arm.

Have tested it in my cluster and now the image gets pulled.