### PR TITLE
Add a more clear message when waiting for successful ssh connectivity…

### DIFF
--- a/src/util/ssh.cr
+++ b/src/util/ssh.cr
@@ -18,7 +18,7 @@ class Util::SSH
   end
 
   def wait_for_server(server, use_ssh_agent, test_command, expected_result)
-    puts "Waiting for server #{server.name}..."
+    puts "Waiting for successful ssh connectivity with server #{server.name}..."
 
     loop do
       sleep 1


### PR DESCRIPTION
… to a newly deployed host

Being more verbose on what the tool is expecting to happen eases debugging for newcomers. 