### PR TITLE
enable custom url for cloud controller manager

### DIFF
--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -214,7 +214,8 @@ class Cluster::Create
       network_name: settings.cluster_name,
       location: settings.masters_pool.location,
       locations: configuration.locations,
-      private_network_subnet: settings.private_network_subnet
+      private_network: settings.private_network,
+      private_network_subnet: settings.private_network_subnet,
     ).run
   end
 
@@ -229,7 +230,7 @@ class Cluster::Create
       ssh_allowed_networks: settings.ssh_allowed_networks,
       api_allowed_networks: settings.api_allowed_networks,
       high_availability: settings.masters_pool.instance_count > 1,
-      private_network_subnet: settings.private_network_subnet
+      private_network: settings.private_network
     ).run
   end
 

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -28,8 +28,10 @@ class Configuration::Main
   getter kubelet_args : Array(String) = [] of String
   getter kube_proxy_args : Array(String) = [] of String
   getter existing_network : String?
+  getter cloud_controller_manager_manifest_url : String?
   getter image : String = "ubuntu-22.04"
   getter autoscaling_image : String = "ubuntu-22.04"
   getter snapshot_os : String = "default"
-  getter private_network_subnet : String = "10.0.0.0/16"
+  getter private_network : String = "10.0.0.0/16"
+  getter private_network_subnet : String = "10.0.0.0/24"
 end

--- a/src/hetzner/firewall/create.cr
+++ b/src/hetzner/firewall/create.cr
@@ -4,7 +4,7 @@ require "./find"
 class Hetzner::Firewall::Create
   getter hetzner_client : Hetzner::Client
   getter firewall_name : String
-  getter private_network_subnet : String
+  getter private_network : String
   getter ssh_allowed_networks : Array(String)
   getter api_allowed_networks : Array(String)
   getter high_availability : Bool
@@ -16,7 +16,7 @@ class Hetzner::Firewall::Create
       @ssh_allowed_networks,
       @api_allowed_networks,
       @high_availability,
-      @private_network_subnet
+      @private_network
     )
     @firewall_finder = Hetzner::Firewall::Find.new(hetzner_client, firewall_name)
   end
@@ -71,7 +71,7 @@ class Hetzner::Firewall::Create
         protocol: "tcp",
         port: "any",
         source_ips: [
-          private_network_subnet
+          private_network
         ],
         destination_ips: [] of String
       },
@@ -81,7 +81,7 @@ class Hetzner::Firewall::Create
         protocol: "udp",
         port: "any",
         source_ips: [
-          private_network_subnet
+          private_network
         ],
         destination_ips: [] of String
       }

--- a/src/hetzner/network/create.cr
+++ b/src/hetzner/network/create.cr
@@ -7,9 +7,10 @@ class Hetzner::Network::Create
   getter location : String
   getter network_finder : Hetzner::Network::Find
   getter locations : Array(Hetzner::Location)
+  getter private_network : String
   getter private_network_subnet : String
 
-  def initialize(@hetzner_client, @network_name, @location, @locations, @private_network_subnet)
+  def initialize(@hetzner_client, @network_name, @location, @locations, @private_network, @private_network_subnet)
     @network_finder = Hetzner::Network::Find.new(@hetzner_client, @network_name)
   end
 
@@ -41,7 +42,7 @@ class Hetzner::Network::Create
 
     {
       name: network_name,
-      ip_range: private_network_subnet,
+      ip_range: private_network,
       subnets: [
         {
           ip_range: private_network_subnet,

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -236,7 +236,11 @@ class Kubernetes::Installer
   private def deploy_cloud_controller_manager
     puts "\nDeploying Hetzner Cloud Controller Manager..."
 
-    command = "kubectl apply -f https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.15.0/ccm-networks.yaml"
+    if settings.cloud_controller_manager_manifest_url
+      command = "kubectl apply -f #{settings.cloud_controller_manager_manifest_url}"
+    else
+      command = "kubectl apply -f https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.15.0/ccm-networks.yaml"
+    end
 
     result = Util::Shell.run(command, configuration.kubeconfig_path, settings.hetzner_token)
 


### PR DESCRIPTION
These settings were needed for me to get a hybrid VPS & bare-metal hetzner cluster running. I made a vSwitch for the 10.0.1.0/24 subnet and changed the firewall settings also in this PR.

```yaml
private_network: 10.0.0.0/16
private_network_subnet: 10.0.0.0/24
schedule_workloads_on_masters: true
cloud_controller_manager_manifest_url: https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml
```