### PR TITLE
api_server_dns setting to support alternate DNS for k8s API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ worker_node_pools:
 # kube_proxy_args:
 # - arg1
 # - ...
-# api_server_dns: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer. 
+# api_server_hostname: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer. 
 ```
 
 Most settings should be self explanatory; you can run `hetzner-k3s releases` to see a list of the available k3s releases.

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ worker_node_pools:
 # kube_proxy_args:
 # - arg1
 # - ...
+# api_server_dns: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer. 
 ```
 
 Most settings should be self explanatory; you can run `hetzner-k3s releases` to see a list of the available k3s releases.

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -14,6 +14,7 @@ class Configuration::Main
   getter use_ssh_agent : Bool = false
   getter ssh_allowed_networks : Array(String) = [] of String
   getter api_allowed_networks : Array(String) = [] of String
+  getter api_server_dns : String?
   getter verify_host_key : Bool = false
   getter schedule_workloads_on_masters : Bool = false
   getter enable_encryption : Bool = false

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -14,7 +14,7 @@ class Configuration::Main
   getter use_ssh_agent : Bool = false
   getter ssh_allowed_networks : Array(String) = [] of String
   getter api_allowed_networks : Array(String) = [] of String
-  getter api_server_dns : String?
+  getter api_server_hostname : String?
   getter verify_host_key : Bool = false
   getter schedule_workloads_on_masters : Bool = false
   getter enable_encryption : Bool = false

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -201,7 +201,7 @@ class Kubernetes::Installer
     puts "Saving the kubeconfig file to #{kubeconfig_path}..."
 
     kubeconfig = ssh.run(first_master, settings.ssh_port, "cat /etc/rancher/k3s/k3s.yaml", settings.use_ssh_agent, print_output: false).
-      gsub("127.0.0.1",  settings.api_server_dns ? settings.api_server_dns : api_server_ip_address).
+      gsub("127.0.0.1",  settings.api_server_hostname ? settings.api_server_hostname : api_server_ip_address).
       gsub("default", settings.cluster_name)
 
     File.write(kubeconfig_path, kubeconfig)
@@ -360,7 +360,7 @@ class Kubernetes::Installer
 
   private def generate_tls_sans
     sans = ["--tls-san=#{api_server_ip_address}"]
-    sans << "--tls-san=#{settings.api_server_dns}" if settings.api_server_dns
+    sans << "--tls-san=#{settings.api_server_hostname}" if settings.api_server_hostname
 
     masters.each do |master|
       master_private_ip = master.private_ip_address

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -201,7 +201,7 @@ class Kubernetes::Installer
     puts "Saving the kubeconfig file to #{kubeconfig_path}..."
 
     kubeconfig = ssh.run(first_master, settings.ssh_port, "cat /etc/rancher/k3s/k3s.yaml", settings.use_ssh_agent, print_output: false).
-      gsub("127.0.0.1", api_server_ip_address).
+      gsub("127.0.0.1",  settings.api_server_dns ? settings.api_server_dns : api_server_ip_address).
       gsub("default", settings.cluster_name)
 
     File.write(kubeconfig_path, kubeconfig)
@@ -360,6 +360,8 @@ class Kubernetes::Installer
 
   private def generate_tls_sans
     sans = ["--tls-san=#{api_server_ip_address}"]
+    sans << "--tls-san=#{settings.api_server_dns}" if settings.api_server_dns
+
     masters.each do |master|
       master_private_ip = master.private_ip_address
       sans << "--tls-san=#{master_private_ip}"


### PR DESCRIPTION
`api_server_dns` setting to support alternate DNS for k8s API server. 

See issue https://github.com/vitobotta/hetzner-k3s/issues/238