### PR TITLE
Bump cluster-autoscaler to v1.27.3

### DIFF
--- a/templates/cluster_autoscaler.yaml
+++ b/templates/cluster_autoscaler.yaml
@@ -155,7 +155,7 @@ spec:
                   - key: node-role.kubernetes.io/master
                     operator: Exists
       containers:
-        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.3
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.3
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
The arm64 machines on Hetzner require cluster-autoscaler v1.27.1 onwards. Prior to that, the wrong architecture is sent to the API and the request fails.