### PR TITLE
private IP of LB in san of k8s api

### DIFF
--- a/src/hetzner/load_balancer.cr
+++ b/src/hetzner/load_balancer.cr
@@ -6,9 +6,14 @@ class Hetzner::LoadBalancer
 
   property id : Int32
   property name : String
+  property private_net : Array(Hetzner::Ipv4)
   getter public_net : PublicNet?
-
+  
   def public_ip_address
     public_net.try(&.ipv4).try(&.ip)
+  end
+
+  def private_ip_address
+    private_net[0].try(&.ip)
   end
 end

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -360,6 +360,8 @@ class Kubernetes::Installer
 
   private def generate_tls_sans
     sans = ["--tls-san=#{api_server_ip_address}"]
+    sans << "--tls-san=#{load_balancer.not_nil!.private_ip_address}" if masters.size > 1
+
     masters.each do |master|
       master_private_ip = master.private_ip_address
       sans << "--tls-san=#{master_private_ip}"


### PR DESCRIPTION
Add the private IP of the load balancer to the certificate of the k8s API server.
 
See https://github.com/vitobotta/hetzner-k3s/issues/238

Tested by creating a single master cluster: OK 
Tested by creating a 3 master cluster: openssl s_client --showcerts shows the SAN of the private IP had been added. 