### PR TITLE
Update version numbers for CSI and CCM manifests.

### DIFF
--- a/cluster_config.yaml.example
+++ b/cluster_config.yaml.example
@@ -19,8 +19,8 @@ disable_flannel: false # set to true if you want to install a different CNI
 # image: rocky-9 # optional: default is ubuntu-22.04
 # autoscaling_image: 103908130 # optional, defaults to the `image` setting
 # snapshot_os: microos # otional: specified the os type when using a custom snapshot
-cloud_controller_manager_manifest_url: "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.16.0/ccm-networks.yaml"
-csi_driver_manifest_url: "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml"
+cloud_controller_manager_manifest_url: "https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.18.0/deploy/ccm-networks.yaml"
+csi_driver_manifest_url: "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml"
 system_upgrade_controller_manifest_url: "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml"
 masters_pool:
   instance_type: cpx21

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -35,8 +35,8 @@ class Configuration::Main
   getter autoscaling_image : String = "ubuntu-22.04"
   getter snapshot_os : String = "default"
   getter private_network_subnet : String = "10.0.0.0/16"
-  getter cloud_controller_manager_manifest_url : String = "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/download/v1.16.0/ccm-networks.yaml"
-  getter csi_driver_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.3.2/deploy/kubernetes/hcloud-csi.yml"
+  getter cloud_controller_manager_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/hcloud-cloud-controller-manager/v1.18.0/deploy/ccm-networks.yaml"
+  getter csi_driver_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.4.0/deploy/kubernetes/hcloud-csi.yml"
   getter system_upgrade_controller_manifest_url : String = "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml"
   getter disable_flannel : Bool = false
   getter ssh_port : Int32 = 22


### PR DESCRIPTION
The PR updates the manifest files to point to latest CSI and CCM versions.

CSI Driver 2.4.0 on 2023-08-25
Cloud controller manager v1.18.0 on 2023-09-18