### PR TITLE
Add support for --disable-proxy option when installing k3s 

### DIFF
--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -42,5 +42,6 @@ class Configuration::Main
   getter csi_driver_manifest_url : String = "https://raw.githubusercontent.com/hetznercloud/csi-driver/v2.5.1/deploy/kubernetes/hcloud-csi.yml"
   getter system_upgrade_controller_manifest_url : String = "https://raw.githubusercontent.com/rancher/system-upgrade-controller/master/manifests/system-upgrade-controller.yaml"
   getter disable_flannel : Bool = false
+  getter disable_kube_proxy : Bool = false
   getter ssh_port : Int32 = 22
 end

--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -128,6 +128,7 @@ class Kubernetes::Installer
       k3s_version: settings.k3s_version,
       k3s_token: k3s_token,
       disable_flannel: settings.disable_flannel.to_s,
+      disable_kube_proxy: settings.disable_kube_proxy.to_s,
       flannel_backend: flannel_backend,
       taint: taint,
       extra_args: extra_args,

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -17,9 +17,9 @@ else
 fi
 
 if [[ "{{ disable_kube_proxy }}" = "true" ]]; then
-  KUBE_PROXY_SETTINGS=" --disable-kube-proxy "
+  KUBE_PROXY_ARGS=" --disable-kube-proxy "
 else
-  KUBE_PROXY_SETTINGS=" --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" "
+  KUBE_PROXY_ARGS=" --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" "
 fi
 
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN="{{ k3s_token }}" INSTALL_K3S_EXEC="server \
@@ -35,7 +35,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN
 --cluster-dns={{ cluster_dns }} \
 --etcd-expose-metrics=true \
 --kube-controller-manager-arg="bind-address=0.0.0.0" \
-$KUBE_PROXY_SETTINGS \
+$KUBE_PROXY_ARGS \
 --kube-scheduler-arg="bind-address=0.0.0.0" \
 {{ taint }} {{ extra_args }} $FLANNEL_SETTINGS \
 --kubelet-arg="cloud-provider=external" \

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -19,7 +19,7 @@ fi
 if [[ "{{ disable_kube_proxy }}" = "true" ]]; then
   KUBE_PROXY_ARGS=" --disable-kube-proxy "
 else
-  KUBE_PROXY_ARGS=" --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" "
+  KUBE_PROXY_ARGS=" --kube-proxy-arg=\metrics-bind-address=0.0.0.0\ "
 fi
 
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN="{{ k3s_token }}" INSTALL_K3S_EXEC="server \

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -16,6 +16,12 @@ else
   FLANNEL_SETTINGS=" {{ flannel_backend }} --flannel-iface=$NETWORK_INTERFACE "
 fi
 
+if [[ "{{ disable_kube_proxy }}" = "true" ]]; then
+  KUBE_PROXY_SETTINGS=" --disable-kube-proxy "
+else
+  KUBE_PROXY_SETTINGS=" --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" "
+fi
+
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN="{{ k3s_token }}" INSTALL_K3S_EXEC="server \
 --disable-cloud-controller \
 --disable servicelb \
@@ -29,7 +35,7 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN
 --cluster-dns={{ cluster_dns }} \
 --etcd-expose-metrics=true \
 --kube-controller-manager-arg="bind-address=0.0.0.0" \
---kube-proxy-arg="metrics-bind-address=0.0.0.0" \
+$KUBE_PROXY_SETTINGS \
 --kube-scheduler-arg="bind-address=0.0.0.0" \
 {{ taint }} {{ extra_args }} $FLANNEL_SETTINGS \
 --kubelet-arg="cloud-provider=external" \


### PR DESCRIPTION
Changed src/configuration/main.cr:
- added disable_kube_proxy variable ( type Bool default value false);

Changed templates/master_install_script.sh:
- added new setting KUBE_PROXY_ARGS;
- set default value to already existing value ("  --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" );
- conditional change into "--disable-kube-proxy" based on disable_kube_proxy option;


Only part I am unsure of is this line:

```
 KUBE_PROXY_ARGS=" --kube-proxy-arg=\"metrics-bind-address=0.0.0.0\" "
```
I am not sure whether the " inside the value need to be escaped or not (I escaped them out of habit, but can't be sure of this).