### PR TITLE
Add a warning about cluster_dns and service_cidr in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ private_network_subnet: 10.0.0.0/16 # ensure this doesn't overlap with other net
 disable_flannel: false # set to true if you want to install a different CNI
 schedule_workloads_on_masters: false
 # cluster_cidr: 10.244.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for pod IPs
-# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs
+# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs. Warning, if you change this, you should also change cluster_dns!
 # cluster_dns: 10.43.0.10 # optional: IPv4 Cluster IP for coredns service. Needs to be an address from the service_cidr range
 # enable_public_net_ipv4: false # default is true
 # enable_public_net_ipv6: false # default is true

--- a/cluster_config.yaml.example
+++ b/cluster_config.yaml.example
@@ -14,7 +14,7 @@ api_allowed_networks:
 schedule_workloads_on_masters: false
 private_network_subnet: 10.0.0.0/16
 # cluster_cidr: 10.244.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for pod IPs
-# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs
+# service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs. Warning, if you change this, you should also change cluster_dns!
 # cluster_dns: 10.43.0.10 # optional: IPv4 Cluster IP for coredns service. Needs to be an address from the service_cidr range
 disable_flannel: false # set to true if you want to install a different CNI
 # enable_public_net_ipv4: false # default is true


### PR DESCRIPTION
As mentioned in #351.

There is already a note about that in the README, but I thought it might help to have it proeminently in the sample configuration as well.