### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,33 @@ Please create a PR if you want to propose any changes, or open an issue if you a
 If you would like to financially support the project, consider [becoming a sponsor](https://github.com/sponsors/vitobotta).
 
 ___
+## Building from source
+
+This tool is written in [Crystal](https://crystal-lang.org/). To build it, or to make some changes in the code and try them, you will need to install Crystal locally, or to work in a container. This repository contains a Dockerfile that builds a container image with Crystal as well as the other required dependencies. There is also a Compose file to conveniently run a container using that image, and mount the source code into the container.
+
+To build and run the development container, run:
+```bash
+docker compose up -d
+```
+
+Then, to enter the container:
+```bash
+docker compose exec hetzner-k3s bash
+```
+
+Once inside the container, you can run `hetzner-k3s` like this:
+```bash
+crystal run ./src/hetzner-k3s.cr -- create --config cluster_config.yaml
+```
+
+To generate a binary, you can do:
+```bash
+crystal build ./src/hetzner-k3s.cr --static
+```
+
+The `--static` flag will make sure that the resulting binary is statically linked, and doesn't have dependencies on libraries that may or may not be available on the system where you will want to run it.
+
+___
 ## License
 
 This tool is available as open source under the terms of the [MIT License](https://github.com/vitobotta/hetzner-k3s/blob/main/LICENSE.txt).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ volumes:
 
 services:
   hetzner-k3s:
+    # If you want to connect to your servers over IPv6 when running in a container,
+    # you will need to configure Docker to provide IPv6 connectivity to containers.
+    # Alternatively, if you're working on Linux and your host machine has IPv6,
+    # you can use "network_mode: host".
+    #network_mode: host
     build:
       context: .
       dockerfile: Dockerfile.dev
@@ -15,3 +20,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - kube:/root/.kube
       - vscode_cache:/vscode/vscode-server:cache
+    working_dir: /home/app/hetzner-k3s


### PR DESCRIPTION
I suppose that these are obvious for someone who is familiar with Crystal; but I wasn't, and it took me a while to figure out how to build the code to test my changes :)

I've also added a working_dir to the Compose file, so that the user is placed directly in the source directory. I hope this won't affect other uses (e.g. inside VSCode).