### PR TITLE
Add instructions about VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,21 @@ If you would like to financially support the project, consider [becoming a spons
 ___
 ## Building from source
 
-This tool is written in [Crystal](https://crystal-lang.org/). To build it, or to make some changes in the code and try them, you will need to install Crystal locally, or to work in a container. This repository contains a Dockerfile that builds a container image with Crystal as well as the other required dependencies. There is also a Compose file to conveniently run a container using that image, and mount the source code into the container.
+This tool is written in [Crystal](https://crystal-lang.org/). To build it, or to make some changes in the code and try them, you will need to install Crystal locally, or to work in a container.
+
+This repository contains a Dockerfile that builds a container image with Crystal as well as the other required dependencies. There is also a Compose file to conveniently run a container using that image, and mount the source code into the container. Finally, there is a devcontainer file that you can use with compatible IDEs like Visual Studio Code and the Dev Containers extension.
+
+
+### Developing with VSCode
+
+You need [Visual Studio Code](https://code.visualstudio.com/) and the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers&ssr=false). Open the project in VSCode (for instance, by executing `code .` in the root directory of this git repository). You should see a pop-up dialog prompting you to "Reopen in Container". Do that, then wait until the build is complete and the server has started; then click on "+" to open a terminal inside the container.
+
+Note: if for some reason you can't find the Dev Containers extension in the Marketplace (for instance, if the first result is the Docker extension instead of Dev Containers), check that you have the official build of VSCode. It looks like if you're running an Open Source build, some extensions are disabled.
+
+
+### Developing with Compose
+
+If you can't or won't install VSCode, you can also develop in the exact same container with Docker and Compose.
 
 To build and run the development container, run:
 ```bash
@@ -517,7 +531,10 @@ Then, to enter the container:
 docker compose exec hetzner-k3s bash
 ```
 
-Once inside the container, you can run `hetzner-k3s` like this:
+
+### Inside the container
+
+Once you are inside the dev container (whether you used VSCode or directly Docker Compose), you can run `hetzner-k3s` like this:
 ```bash
 crystal run ./src/hetzner-k3s.cr -- create --config cluster_config.yaml
 ```


### PR DESCRIPTION
As requested on #355, I've added instructions about VSCode.

I had some issues running the Dev Containers extension; apparently it's not available with the open source build of VSCode; I had to install the "upstream" build and then it worked fine.