### PR TITLE
k3s install only AFTER cloud init is done

### DIFF
--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,8 +1,13 @@
+while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+	echo "Awaiting cloud boot-finished..."
+	sleep 5
+done
+
 touch /etc/initialized
 
-if [[ $(< /etc/initialized) != "true" ]]; then
-  systemctl restart NetworkManager || true
-  dhclient eth1 -v || true
+if [[ $(</etc/initialized) != "true" ]]; then
+	systemctl restart NetworkManager || true
+	dhclient eth1 -v || true
 fi
 
 HOSTNAME=$(hostname -f)
@@ -11,9 +16,9 @@ PUBLIC_IP=$(hostname -I | awk '{print $1}')
 NETWORK_INTERFACE=$(ip route get {{ private_network_test_ip }} | awk -F"dev " 'NR==1{split($2,a," ");print a[1]}')
 
 if [[ "{{ disable_flannel }}" = "true" ]]; then
-  FLANNEL_SETTINGS=" --flannel-backend=none --disable-kube-proxy --disable-network-policy "
+	FLANNEL_SETTINGS=" --flannel-backend=none --disable-kube-proxy --disable-network-policy "
 else
-  FLANNEL_SETTINGS=" {{ flannel_backend }} --flannel-iface=$NETWORK_INTERFACE "
+	FLANNEL_SETTINGS=" {{ flannel_backend }} --flannel-iface=$NETWORK_INTERFACE "
 fi
 
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN="{{ k3s_token }}" {{ datastore_endpoint }} INSTALL_K3S_EXEC="server \
@@ -40,4 +45,4 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" K3S_TOKEN
 
 systemctl start k3s # on some OSes the service doesn't start automatically for some reason
 
-echo true > /etc/initialized
+echo true >/etc/initialized


### PR DESCRIPTION
For k3s clusers with private IPs only, cloud init is typically required, so that the nodes can reach the internet, e.g. to download k3s.

=> Lets wait until cloud init is finished, before trying to download k3s.

Fixes #379 #366 #297 and mabye a few others. With this, hetzner-k3s runs through, w/o the need to restart.

Note: The file tested is always present on hetzner cloud instances, even w/o cloud init 
=> that presence test should not cause problems elsewhere.

