### PR TITLE
Fix SSH when using non-default port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ temp
 docker-compose.override.yml
 cilium
 calicoctl
+
+e2e-tests/env
+e2e-tests/sshkey*
+e2e-tests/test-*

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,72 @@
+# End-to-end test harness
+
+This directory contains a few scripts to automate testing of hetzner-k3s across different combinations of configurations.
+
+## How to use this?
+
+Copy `env.sample` to `env` and edit it to indicate your Hetzner API token. You can also change the instance location if you'd like, and the location of the hetzner-k3s binary that you would like to use for testing (convenient if you're building multiple, different versions and want to check for regressions).
+
+Then to run a single test:
+
+```bash
+./run-single-test.sh config-sshport-image.yaml IMAGE=ubuntu-22.04 SSHPORT=222
+```
+
+The first argument is a configuration file template; the rest of the command line is an optional list of variables to substitute in the template.
+
+To run all the tests:
+
+```bash
+./run-all-tests.sh
+```
+
+To view test results:
+
+```
+./list-test-results.sh
+```
+
+The output will look like this:
+```
+$ ./list-test-results.sh
+config-sshport-image.yaml  IMAGE=alma-8 SSHPORT=222           error  creating   test-c59dc574
+config-sshport-image.yaml  IMAGE=alma-8 SSHPORT=22            error  creating   test-15c94339
+config-sshport-image.yaml  IMAGE=alma-9 SSHPORT=222           ok     tested ok  test-e9acedda
+config-sshport-image.yaml  IMAGE=alma-9 SSHPORT=22            ok     tested ok  test-3a378dbe
+config-sshport-image.yaml  IMAGE=centos-stream-8 SSHPORT=222  error  done       test-9063a269
+config-sshport-image.yaml  IMAGE=centos-stream-8 SSHPORT=22   error  done       test-0a523221
+config-sshport-image.yaml  IMAGE=centos-stream-9 SSHPORT=222  ok     done       test-857926a8
+config-sshport-image.yaml  IMAGE=debian-11 SSHPORT=222        ok     done       test-fe655f1c
+config-sshport-image.yaml  IMAGE=debian-11 SSHPORT=22         ok     tested ok  test-77bf45fe
+...
+config-sshport-image.yaml  IMAGE=ubuntu-24.04 SSHPORT=222     ok     tested ok  test-b7c132d6
+```
+
+## Re-running a test
+
+The test uses a caching system: if you run the same test (same configuration file and same parameters) twice, it will skip it the second time. This is so that you can add a test in the "run-all-tests.sh" script, and re-run it to execute only the new tests that you added.
+
+If you want to re-run a test, delete the corresponding directory: it's the `test-xxxxxxxx` directory shown by `list-test-results.sh`.
+
+## What does it test, exactly?
+
+It executes `hetzner-k3s create`, then executes a few very basic `kubectl` commands, then executes `hetzner-k3s delete`.
+
+Each test is executed in a separate directory (`test-xxxxxxxx` show by `list-test-results.sh`), and the output of each phase is put in a log file in that directory. Status files are also created to track test success or failure.
+
+## That seems very primitive.
+
+It is! The goal was to test if the SSH port option worked correctly across all distros. I thought this could be useful to test other options and combinations of options later.
+
+## It takes a very long time!
+
+Yes, because the tests are executed sequentially, not in parallel. This is because the default Hetzner quotas are fairly low (10 instance, I believe?) and executing more than a couple of tests simultaneously (or in an account that already has a couple of instances running) would exceed the quota and cause the tests to fail.
+
+It would be fairly easy to parallelize the tests if the needs arise, but we should then keep in mind that most folks will have this conservative instance quota, that will cause tests to fail.
+
+## How much will this cost to run?
+
+The instances will only run for a couple of minutes each time. I ran a bunch of tests with a bunch of different configurations and it probably cost me 1-2 EUR, but of course, the size of the instances will influence this; and if you interrupt the test while instances are running (or if it crashes badly enough during the test) some instances might still be running and you will need to clean them up manually!
+
+
+

--- a/e2e-tests/config-simple.yaml
+++ b/e2e-tests/config-simple.yaml
@@ -1,0 +1,47 @@
+---
+cluster_name: $NAME
+kubeconfig_path: $KUBECONFIG
+k3s_version: v1.30.2+k3s2
+
+networking:
+  ssh:
+    port: 22
+    use_agent: false # set to true if your key has a passphrase
+    public_key_path: sshkey.pub
+    private_key_path: sshkey
+  allowed_networks:
+    ssh:
+      - 0.0.0.0/0
+    api: # this will firewall port 6443 on the nodes; it will NOT firewall the API load balancer
+      - 0.0.0.0/0
+  public_network:
+    ipv4: true
+    ipv6: true
+  private_network:
+    enabled : true
+    subnet: 10.0.0.0/16
+    existing_network_name: ""
+  cni:
+    enabled: true
+    encryption: false
+    mode: flannel
+
+datastore:
+  mode: etcd # etcd (default) or external
+
+schedule_workloads_on_masters: false
+
+masters_pool:
+  instance_type: cpx11
+  instance_count: 3
+  location: $LOCATION
+
+worker_node_pools:
+- name: pool1
+  instance_type: cpx11
+  instance_count: 1
+  location: $LOCATION
+
+embedded_registry_mirror:
+  enabled: true
+

--- a/e2e-tests/config-sshport-image.yaml
+++ b/e2e-tests/config-sshport-image.yaml
@@ -1,0 +1,49 @@
+---
+cluster_name: $NAME
+kubeconfig_path: $KUBECONFIG
+k3s_version: v1.30.2+k3s2
+
+image: $IMAGE
+
+networking:
+  ssh:
+    port: $SSHPORT
+    use_agent: false # set to true if your key has a passphrase
+    public_key_path: sshkey.pub
+    private_key_path: sshkey
+  allowed_networks:
+    ssh:
+      - 0.0.0.0/0
+    api: # this will firewall port 6443 on the nodes; it will NOT firewall the API load balancer
+      - 0.0.0.0/0
+  public_network:
+    ipv4: true
+    ipv6: true
+  private_network:
+    enabled : true
+    subnet: 10.0.0.0/16
+    existing_network_name: ""
+  cni:
+    enabled: true
+    encryption: false
+    mode: flannel
+
+datastore:
+  mode: etcd # etcd (default) or external
+
+schedule_workloads_on_masters: false
+
+masters_pool:
+  instance_type: cpx11
+  instance_count: 3
+  location: $LOCATION
+
+worker_node_pools:
+- name: pool1
+  instance_type: cpx11
+  instance_count: 1
+  location: $LOCATION
+
+embedded_registry_mirror:
+  enabled: true
+

--- a/e2e-tests/env.sample
+++ b/e2e-tests/env.sample
@@ -1,0 +1,3 @@
+export HCLOUD_TOKEN=...
+export LOCATION=ash
+export HK3S=../hetzner-k3s

--- a/e2e-tests/list-test-results.sh
+++ b/e2e-tests/list-test-results.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+for T in test-*; do
+  printf "%s\t%s\t%s\t%s\t%s\n" \
+    "$(cat $T/config)" \
+    "$(cat $T/args)" \
+    "$(cat $T/result)" \
+    "$(cat $T/status)" \
+    "$T"
+done | sort | column -t -s "	"

--- a/e2e-tests/run-all-tests.sh
+++ b/e2e-tests/run-all-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+T=./run-single-test.sh
+
+$T config-sshport-image.yaml IMAGE=debian-11 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=debian-11 SSHPORT=22
+$T config-sshport-image.yaml IMAGE=debian-12 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=ubuntu-20.04 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=ubuntu-22.04 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=ubuntu-24.04 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=alma-8 SSHPORT=22
+$T config-sshport-image.yaml IMAGE=alma-8 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=alma-9 SSHPORT=22
+$T config-sshport-image.yaml IMAGE=alma-9 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=rocky-8 SSHPORT=22
+$T config-sshport-image.yaml IMAGE=rocky-8 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=rocky-9 SSHPORT=22
+$T config-sshport-image.yaml IMAGE=fedora-38 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=fedora-39 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=fedora-40 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=centos-stream-8 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=centos-stream-9 SSHPORT=222
+$T config-sshport-image.yaml IMAGE=centos-stream-8 SSHPORT=22

--- a/e2e-tests/run-single-test.sh
+++ b/e2e-tests/run-single-test.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -eu
+set -o pipefail
+. ./env # this env file should set HCLOUD_TOKEN, and perhaps LOCATION and HK3S
+HK3S=${HK3S-hetzner-k3s}
+CONFIG=$1
+shift
+HASH=$({
+  echo "---"
+  echo "$@"
+  echo "---"
+  cat "$CONFIG"
+  } | sha256sum | cut -c1-8)
+export NAME="test-$HASH"
+OUTDIR="$NAME"
+export LOCATION=${LOCATION-ash}
+export KUBECONFIG="$OUTDIR/kubeconfig"
+export "$@"
+if [ -d "$OUTDIR" ]; then
+  echo "Output directory '$OUTDIR' already exists."
+  echo "Remove or rename it if you want to run that test again."
+  exit 1
+fi
+echo "Creating output directory: $OUTDIR"
+mkdir -p "$OUTDIR"
+envsubst < "$CONFIG" > "$OUTDIR/config.yaml"
+echo "$*" > "$OUTDIR/args"
+echo "$CONFIG" > "$OUTDIR/config"
+
+if ! [ -f sshkey ]; then
+  ssh-keygen -f sshkey -t ed25519 -N ""
+fi
+
+echo "pending" > "$OUTDIR/result"
+echo "creating" > "$OUTDIR/status"
+if timeout 5m "$HK3S" create --config "$OUTDIR/config.yaml" | tee "$OUTDIR/create.log" 2>&1 ; then
+(
+  echo "testing" > "$OUTDIR/status"
+  set +x -e
+  kubectl get nodes -o wide
+  kubectl create deployment blue --image jpetazzo/color
+  kubectl expose deployment blue --port 80
+  kubectl wait deployment blue --for=condition=Available
+  kubectl run --rm -it --restart=Never --image curlimages/curl curl http://blue
+  echo "ok" > "$OUTDIR/result"
+) | tee "$OUTDIR/kubectl.log" 2>&1 || true
+fi
+echo "deleting" > "$OUTDIR/status"
+timeout 5m "$HK3S" delete --config "$OUTDIR/config.yaml" | tee "$OUTDIR/delete.log" 2>&1
+if ! grep -qw ok "$OUTDIR/result"; then
+  echo "error" > "$OUTDIR/result"
+fi
+echo "done" > "$OUTDIR/status"
+

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -212,6 +212,8 @@ class Hetzner::Instance::Create
     [
       "hostnamectl set-hostname $(curl http://169.254.169.254/hetzner/v1/metadata/hostname)",
       "update-crypto-policies --set DEFAULT:SHA1 || true",
+      "systemctl disable --now ssh.socket || true",
+      "systemctl enable --now ssh.service || true",
       "echo \"nameserver 8.8.8.8\" > /etc/k8s-resolv.conf"
     ]
   end


### PR DESCRIPTION
Since Ubuntu 22.10, SSH uses socket activation. This means that the SSH server isn't running by default, and gets started automatically the first time there is a connection on port 22.

Upside: it saves 3 MB of RAM.

Downside: if you're customizing the SSH port number with a drop-in configuration file at cloud-init time, it breaks SSH. SSH then needs to be restarted (or the machine needs to be rebooted) for the port number to be picked up by the systemd generator. The net result for hetzner-k3s is that if we use a non-default SSH port, provisioning breaks.

This manifests itself by the following log message:
```
  systemd[1]: ssh.socket: Socket unit configuration has changed while
  unit has been running, no open socket file descriptor left. The
  socket unit is not functional until restarted.
```
One possible fix is to disable socket activation and revert to the default mode (start SSH at boot). This can be done by disabling ssh.socket and enabling ssh.service.

This patch does exactly that, adding the corresponding commands to the cloud-init template. This has been tested with Ubuntu 24.04 and 22.04 as well.

The following link has more details on the Ubuntu change:

https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189/14