### PR TITLE
Cloud init and Timeout from 30 to 60

### DIFF
--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -272,7 +272,7 @@ class Cluster::Create
         instance = nil
         begin
           Retriable.retry(max_attempts: 3, on: Tasker::Timeout, backoff: false) do
-            Tasker.timeout(30.seconds) do
+            Tasker.timeout(60.seconds) do
               instance = instance_creator.run
             end
           end

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,7 +1,17 @@
-while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
-	echo "Awaiting cloud/instance/boot-finished..."
-	sleep 5
-done
+fn_cloud="/var/lib/cloud/instance/boot-finished"
+function await_cloud_init() {
+  echo "🕒 Awaiting cloud config (may take a minute...)"
+  while true; do
+    for _ in $(seq 1 10); do
+      test -f $fn_cloud && return
+      sleep 1
+    done
+    echo -n "."
+  done
+}
+test -f $fn_cloud || await_cloud_init
+echo "Cloud init finished: $(cat $fn_cloud)"
+
 
 touch /etc/initialized
 

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -1,7 +1,16 @@
-while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
-	echo "Awaiting cloud/instance/boot-finished..."
-	sleep 5
-done
+fn_cloud="/var/lib/cloud/instance/boot-finished"
+function await_cloud_init() {
+  echo "🕒 Awaiting cloud config (may take a minute...)"
+  while true; do
+    for _ in $(seq 1 10); do
+      test -f $fn_cloud && return
+      sleep 1
+    done
+    echo -n "."
+  done
+}
+test -f $fn_cloud || await_cloud_init
+echo "Cloud init finished: $(cat $fn_cloud)"
 
 touch /etc/initialized
 


### PR DESCRIPTION
Hi, sorry, 2 things in one PR. 

The cloud init improvements we discussed in #389.

BUT also: Today I get consistently timeout errors at k3s install time.

```
[Instance ax-master2] Waiting for successful ssh connectivity with instance ax-master2...
[Instance ax-master1] Instance ax-master1 already exists, skipping create
[Instance ax-master3] Instance status: running
[Instance ax-master3] Waiting for successful ssh connectivity with instance ax-master3...
[Instance ax-master1] Instance status: running
[Instance ax-master1] Waiting for successful ssh connectivity with instance ax-master1...
[Instance ax-master2] ...instance ax-master2 is now up.
[Instance ax-master2] ...instance ax-master2 created
[Instance ax-master2] ...instance ax-master2 is now up.
Error creating instance: timeout after 00:00:30
Instance creation for ax-master3 failed. Try rerunning the create command.
Error creating instance: timeout after 00:00:30
Instance creation for ax-master1 failed. Try rerunning the create command.
[Instance ax-master1] ...instance ax-master1 is now up.
[Instance ax-master2] ...instance ax-master2 is now up.
[Instance ax-master3] ...instance ax-master3 is now up.
[Instance ax-master3] ...instance ax-master3 is now up.
```

and it does not recover from there - would have to restart the installer, then it would run through.

The only fix which allows consistently working single shot installs was to increase those 30 to 60 - then it runs through. 

Interesting is that after waiting that long the cloud init is done, when master_install runs, i.e. I don't even see the ""🕒 Awaiting cloud config (may take a minute...)" message today, just the success message from "Cloud init finished: $(cat $fn_cloud)" 

Cheers,
Gunther

PS: I can confirm the ssh port problem @jpetazzo  reports in the other PR, works only with port 22 with ubuntu.
