### PR TITLE
fix: #393 My wait function definition was buggy, causing autosc. crash

### DIFF
--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,5 +1,5 @@
 fn_cloud="/var/lib/cloud/instance/boot-finished"
-function await_cloud_init() {
+function await_cloud_init {
   echo "🕒 Awaiting cloud config (may take a minute...)"
   while true; do
     for _ in $(seq 1 10); do

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -1,5 +1,5 @@
 fn_cloud="/var/lib/cloud/instance/boot-finished"
-function await_cloud_init() {
+function await_cloud_init {
   echo "🕒 Awaiting cloud config (may take a minute...)"
   while true; do
     for _ in $(seq 1 10); do


### PR DESCRIPTION
My erroneous brackets in the function definition are detected by the syntax checker, when applied via cloud init - and cause it to crash(!) You merged #393 yesterday and did not build a release yet, so I think not many ppl have seen it - but still:

Very sorry for that!

This is taken from cloud init output log of an autoscaler created node:

```
/var/lib/cloud/instance/scripts/runcmd: 3: update-crypto-policies: not found
/var/lib/cloud/instance/scripts/runcmd: 31: Syntax error: "(" unexpected 2024-07-31 14:05:56,542 - cc_scripts_user.py[WARNING]: Failed to run module scripts_user (scripts in /var/lib/cloud/instance/scripts) 2024-07-31 14:05:56,543 - util.py[WARNING]: Running module scripts_user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_scripts_user.py'>) failed Cloud-init v. 24.1.3-0ubuntu3.3 finished at Wed, 31 Jul 2024 14:05:56 +0000. Datasource DataSourceHetzner.  Up 71.52 seconds root@medium-autoscaled-7f6c47d6d68125cb:~#
```