### PR TITLE
Fixes for installer scripts

### DIFF
--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -276,7 +276,7 @@ class Kubernetes::Installer
     log_line "Saving the kubeconfig file to #{kubeconfig_path}...", "Control plane"
 
     kubeconfig = ssh.run(first_master, settings.networking.ssh.port, "cat /etc/rancher/k3s/k3s.yaml", settings.networking.ssh.use_agent, print_output: false).
-      gsub("127.0.0.1",  settings.api_server_hostname ? settings.api_server_hostname : api_server_ip_address(master_count)).
+      gsub("127.0.0.1",  api_server_ip_address(master_count)).
       gsub("default", settings.cluster_name)
 
     File.write(kubeconfig_path, kubeconfig)

--- a/src/kubernetes/software/cluster_autoscaler.cr
+++ b/src/kubernetes/software/cluster_autoscaler.cr
@@ -39,7 +39,13 @@ class Kubernetes::Software::ClusterAutoscaler
   end
 
   private def k3s_join_script
-    "|\n    #{worker_install_script.gsub("\n", "\n    ")}"
+    start_index = worker_install_script.index("touch /etc/initialized") || 0
+    # make sure we early detect, when this line would be changed in the worker install script.
+    # Keeping "cloud init finished"-detection within the autoscaled nodes would deadlock,
+    # since there we run it *during* cloud init.
+    raise "Error: 'touch /etc/initialized' not found in worker_install_script" unless start_index
+    script_part = worker_install_script[start_index..-1]
+    "|\n    #{script_part.gsub("\n", "\n    ")}"
   end
 
   private def certificate_path

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -15,7 +15,7 @@ echo "Cloud init finished: $(cat $fn_cloud)"
 
 touch /etc/initialized
 
-if [[ $(< /etc/initialized) != "true" ]]; then
+if [ "$(cat /etc/initialized 2>/dev/null)" != "true" ]; then
   systemctl restart NetworkManager || true
   dhclient eth1 -v || true
 fi
@@ -23,7 +23,7 @@ fi
 HOSTNAME=$(hostname -f)
 PUBLIC_IP=$(hostname -I | awk '{print $1}')
 
-if [[ "{{ private_network_enabled }}" = "true" ]]; then
+if [ "{{ private_network_enabled }}" = "true" ]; then
   PRIVATE_IP=$(ip route get {{ private_network_test_ip }} | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
   NETWORK_INTERFACE=" --flannel-iface=$(ip route get {{ private_network_test_ip }} | awk -F"dev " 'NR==1{split($2,a," ");print a[1]}') "
 else
@@ -31,13 +31,13 @@ else
   NETWORK_INTERFACE=" "
 fi
 
-if [[ "{{ cni }}" = "true" ]] && [[ "{{ cni_mode }}" = "flannel" ]]; then
+if [ "{{ cni }}" = "true" ] && [ "{{ cni_mode }}" = "flannel" ]; then
   FLANNEL_SETTINGS=" {{ flannel_backend }} $NETWORK_INTERFACE "
 else
   FLANNEL_SETTINGS=" {{ flannel_backend }} "
 fi
 
-if [[ "{{ embedded_registry_mirror_enabled }}" = "true" ]]; then
+if [ "{{ embedded_registry_mirror_enabled }}" = "true" ]; then
   EMBEDDED_REGISTRY_MIRROR=" --embedded-registry "
 else
   EMBEDDED_REGISTRY_MIRROR=" "

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,5 +1,5 @@
 fn_cloud="/var/lib/cloud/instance/boot-finished"
-function await_cloud_init {
+await_cloud_init() {
   echo "🕒 Awaiting cloud config (may take a minute...)"
   while true; do
     for _ in $(seq 1 10); do

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -1,5 +1,5 @@
 fn_cloud="/var/lib/cloud/instance/boot-finished"
-function await_cloud_init {
+await_cloud_init() {
   echo "🕒 Awaiting cloud config (may take a minute...)"
   while true; do
     for _ in $(seq 1 10); do

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -14,7 +14,7 @@ echo "Cloud init finished: $(cat $fn_cloud)"
 
 touch /etc/initialized
 
-if [[ $(< /etc/initialized) != "true" ]]; then
+if [ "$(cat /etc/initialized 2>/dev/null)" != "true" ]; then
   systemctl restart NetworkManager || true
   dhclient eth1 -v || true
 fi
@@ -22,7 +22,7 @@ fi
 HOSTNAME=$(hostname -f)
 PUBLIC_IP=$(hostname -I | awk '{print $1}')
 
-if [[ "{{ private_network_enabled }}" = "true" ]]; then
+if [ "{{ private_network_enabled }}" = "true" ]; then
   PRIVATE_IP=$(ip route get {{ private_network_test_ip }} | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
   NETWORK_INTERFACE=" --flannel-iface=$(ip route get {{ private_network_test_ip }} | awk -F"dev " 'NR==1{split($2,a," ");print a[1]}') "
 else


### PR DESCRIPTION
#### 1. Make install scripts POSIX compliant, so that they run for autoscaled nodes in priv ip situations (and also on minimal distris w/o bash). 

Note: Besides the `if [[ ..]]` checks which were failing on autoscaled nodes: What I thought was a bug in `function await_cloud_init () { ...}` is also just a bashism, like all the others in that script - it IS allowed in bash (that's why my LSP did not complain).
Removing the brackets made it working, since it *is* accepted by the minimal shell in which cloud-init runs,. But it is still not posix compliant - there it must be `await_cloud_init() { ...}` .  

**Affects**
- templates/master_install_script.sh
- templates/worker_install_script.sh

**Ref**  #395

----

#### 2. Prevent the cloud init finished detection to be part of the cloud init on **autoscaled** nodes.  

I did it by cutting off all before 'touch /etc/initialized', which is a bit risky regarding changes of that line later, so I also  added a check if that line is really in, hard failing if not, so one will see the effect immediately and can adapt.

Good news: We have **no**(!) problem with the current v1 release - there the waiting for cloud init is NOT in the worker_install_script.sh, which is merged into the cloud init of autoscaled ones. It is only in the master install script.
Of course worker creation might fail on non autoscaled workers, w/o the waiting for finished, but in v1 it always was like this.

**Affects**
- src/kubernetes/software/cluster_autoscaler.cr

**Ref**  #394



----

#### 3. Solve timeout when api_server_hostname is given.

[docs](https://github.com/vitobotta/hetzner-k3s/blob/v2.0.0.rc1/docs/Creating_a_cluster.md) say `# api_server_hostname: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer.`

And indeed, the user can't do this BEFORE running the script, not knowing the IP of the API LB created.

But since we set that hostname into the kubeconfig, when we do `save_kubeconfig(master_count)` and in the next command do `kubectl cluster-info`, this can't work - since at that time the DNS is not configured to point to that api loadbalancer.

My suggested fix is to set the **IP** of the LB into the kubeconfig. Then all will work and the user can, at his pace, configure his DNS to point to the api lb for that hostname - and only then adapt the kubeconfig, if wanted. SSL will work since we configure tls-sans for that hostname anyway.
But kubeconfig, we can't do this for the user, having no control over if and when he configures his DNS. 

**Affects**
- src/kubernetes/installer.cr

**Ref** None, no issue created.


----

#### 4. Suggested Feature

Vito, would you accept a PR for the feature below, did not dare to put it in here - but it would help me a lot.

Thing is: I don't want the API loadbalancer, keep deleting it anyway and point my kubectl to one of the masters. 

So this would allow to have it set to the first master via the "api_server_hostname" key:


```diff
diff --git a/src/kubernetes/installer.cr b/src/kubernetes/installer.cr
index 8f33273..27c6735 100644
--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -358,6 +358,10 @@ class Kubernetes::Installer
   end

   private def api_server_ip_address(master_count : Int)
-    master_count > 1 ? load_balancer.not_nil!.public_ip_address.not_nil! : first_master.host_ip_address.not_nil!
+    if settings.api_server_hostname == "first_master"
+      first_master.host_ip_address.not_nil!
+    else
+      master_count > 1 ? load_balancer.not_nil!.public_ip_address.not_nil! : first_master.host_ip_address.not_nil!
+    end
   end
 end
 ```


 
 Add Note: Yesterday, all day, the LB status never(!) went healthy, allthough 6443 ports where all listening,
 hetzner had problems. This feature here allows installs nevertheless, while with the current version there is no way, in such a situation, to get the installer running through. Not sure naturally how often this happens. 
 
![2024-07-31_1096x521_scrot](https://github.com/user-attachments/assets/370e3f15-ed76-42c6-9674-27b0b9209ab6)