### PR TITLE
fix: Filter cloud init wait

### DIFF
--- a/src/kubernetes/software/cluster_autoscaler.cr
+++ b/src/kubernetes/software/cluster_autoscaler.cr
@@ -40,7 +40,13 @@ class Kubernetes::Software::ClusterAutoscaler
   end
 
   private def k3s_join_script
-    "|\n    #{worker_install_script.gsub("\n", "\n    ")}"
+    start_index = worker_install_script.index("touch /etc/initialized") || 0
+    # make sure we early detect, when this line would be changed in the worker install script.
+    # Keeping "cloud init finished"-detection within the autoscaled nodes would deadlock,
+    # since there we run it *during* cloud init.
+    raise "Error: 'touch /etc/initialized' not found in worker_install_script" unless start_index
+    script_part = worker_install_script[start_index..-1]
+    "|\n    #{script_part.gsub("\n", "\n    ")}"
   end
 
   private def certificate_path


### PR DESCRIPTION
Autoscaled nodes run the worker install script *within* cloud init itself.

There we can't wait for the file demarking finished, will never happen, since we are not finished ->
we are stuck, waiting, deadlocked.