### PR TITLE
Api server hostname timeout

### DIFF
--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -215,7 +215,7 @@ class Kubernetes::Installer
     puts "Saving the kubeconfig file to #{kubeconfig_path}..."
 
     kubeconfig = ssh.run(first_master, settings.ssh_port, "cat /etc/rancher/k3s/k3s.yaml", settings.use_ssh_agent, print_output: false).
-      gsub("127.0.0.1",  settings.api_server_hostname ? settings.api_server_hostname : api_server_ip_address).
+      gsub("127.0.0.1",  api_server_ip_address).
       gsub("default", settings.cluster_name)
 
     File.write(kubeconfig_path, kubeconfig)

--- a/src/kubernetes/software/cluster_autoscaler.cr
+++ b/src/kubernetes/software/cluster_autoscaler.cr
@@ -40,7 +40,13 @@ class Kubernetes::Software::ClusterAutoscaler
   end
 
   private def k3s_join_script
-    "|\n    #{worker_install_script.gsub("\n", "\n    ")}"
+    start_index = worker_install_script.index("touch /etc/initialized") || 0
+    # make sure we early detect, when this line would be changed in the worker install script.
+    # Keeping "cloud init finished"-detection within the autoscaled nodes would deadlock,
+    # since there we run it *during* cloud init.
+    raise "Error: 'touch /etc/initialized' not found in worker_install_script" unless start_index
+    script_part = worker_install_script[start_index..-1]
+    "|\n    #{script_part.gsub("\n", "\n    ")}"
   end
 
   private def certificate_path


### PR DESCRIPTION
[docs](https://github.com/vitobotta/hetzner-k3s/blob/v2.0.0.rc1/docs/Creating_a_cluster.md) say # api_server_hostname: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer.

And indeed, the user can't do this BEFORE running the script, not knowing the IP of the API LB created.

But since we set that hostname into the kubeconfig, when we do save_kubeconfig(master_count) and in the next command do kubectl cluster-info, this can't work - since at that time the DNS is not configured to point to that api loadbalancer.

My suggested fix is to set the IP of the LB into the kubeconfig. Then all will work and the user can, at his pace, configure his DNS to point to the api lb for that hostname - and only then adapt the kubeconfig, if wanted. SSL will work since we configure tls-sans for that hostname anyway.
But kubeconfig, we can't do this for the user, having no control over if and when he configures his DNS.

Affects

    src/kubernetes/installer.cr

Ref None, no issue created.