### PR TITLE
fix: solve timeout when api server hostname is given

### DIFF
--- a/src/kubernetes/installer.cr
+++ b/src/kubernetes/installer.cr
@@ -276,7 +276,7 @@ class Kubernetes::Installer
     log_line "Saving the kubeconfig file to #{kubeconfig_path}...", "Control plane"
 
     kubeconfig = ssh.run(first_master, settings.networking.ssh.port, "cat /etc/rancher/k3s/k3s.yaml", settings.networking.ssh.use_agent, print_output: false).
-      gsub("127.0.0.1",  settings.api_server_hostname ? settings.api_server_hostname : api_server_ip_address(master_count)).
+      gsub("127.0.0.1",  api_server_ip_address(master_count)).
       gsub("default", settings.cluster_name)
 
     File.write(kubeconfig_path, kubeconfig)


### PR DESCRIPTION
docs say # api_server_hostname: k8s.example.com # optional: DNS for the k8s API LoadBalancer. After the script has run, create a DNS record with the address of the API LoadBalancer.

And indeed, the user can't do this BEFORE running the script, not knowing the IP of the API LB created.

But since we set that hostname into the kubeconfig, when we do save_kubeconfig(master_count) and in the next command do kubectl cluster-info, this can't work - since at that time the DNS is not configured to point to that api loadbalancer.

My suggested fix is to set the IP of the LB into the kubeconfig. Then all will work and the user can, at his pace, configure his DNS to point to the api lb for that hostname - and only then adapt the kubeconfig, if wanted. SSL will work since we configure tls-sans for that hostname anyway. But kubeconfig, we can't do this for the user, having no control over if and when he configures his DNS.

`