### PR TITLE
Upgrade `crest` shard

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   crest:
     git: https://github.com/mamantoha/crest.git
-    version: 1.3.13
+    version: 1.4.1
 
   crinja:
     git: https://github.com/straight-shoota/crinja.git
@@ -26,7 +26,7 @@ shards:
 
   http_proxy:
     git: https://github.com/mamantoha/http_proxy.git
-    version: 0.10.3
+    version: 0.12.0
 
   ipaddress:
     git: https://github.com/sija/ipaddress.cr.git


### PR DESCRIPTION
As noted on #309, I'm still seeing the same OpenSSL error when deploying a cluster from Fedora 40. This pull request upgrades the `crest` shard to the latest version. This fixes the deployment issue.