### PR TITLE
Switch to standard cluster-autoscaler image

### DIFF
--- a/src/kubernetes/software/cluster_autoscaler.cr
+++ b/src/kubernetes/software/cluster_autoscaler.cr
@@ -94,7 +94,7 @@ class Kubernetes::Software::ClusterAutoscaler
   end
 
   private def patch_autoscaler_container(autoscaler_container)
-    autoscaler_container.image = "docker.io/hetznercloud/cluster-autoscaler:v1.31.0-hcloud1"
+    autoscaler_container.image = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.1"
     autoscaler_container.command = container_command
 
     set_container_environment_variable(autoscaler_container, "HCLOUD_CLOUD_INIT", Base64.strict_encode(cloud_init))


### PR DESCRIPTION
Hetzner started sending emails to all customers using the docker.io/hetznercloud/cluster-autoscaler images. The email reads that these images were only provided temporarily until offical releases by upstream cluster-autoscaler were ready. They ask us to start using the official images and that they will REMOVE their own images on November 19 2024.

I have tested this by rebuilding the CLI tool, creating a cluster and creating a deployment that triggered the autoscaler.