### PR TITLE
Ignore instance type in instance name

### DIFF
--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -128,9 +128,18 @@ class Cluster::Create
   end
 
   private def create_master_instance(index : Int32, placement_group : Hetzner::PlacementGroup?) : Hetzner::Instance::Create
+    legacy_instance_type = settings.masters_pool.legacy_instance_type
     instance_type = settings.masters_pool.instance_type
 
-    master_name = if settings.include_instance_type_in_instance_name
+    legacy_instance_type_name_part = legacy_instance_type.blank? ? "" : "#{legacy_instance_type}-"
+
+    legacy_instance_name = if settings.include_instance_type_in_instance_name
+      "#{settings.cluster_name}-#{legacy_instance_type_name_part}#{instance_type}-master#{index + 1}"
+    else
+      "#{settings.cluster_name}-#{legacy_instance_type_name_part}master#{index + 1}"
+    end
+
+    instance_name = if settings.include_instance_type_in_instance_name
       "#{settings.cluster_name}-#{instance_type}-master#{index + 1}"
     else
       "#{settings.cluster_name}-master#{index + 1}"
@@ -144,7 +153,8 @@ class Cluster::Create
       settings: settings,
       hetzner_client: hetzner_client,
       mutex: mutex,
-      instance_name: master_name,
+      legacy_instance_name: legacy_instance_name,
+      instance_name: instance_name,
       instance_type: instance_type,
       image: image,
       ssh_key: ssh_key,
@@ -225,9 +235,18 @@ class Cluster::Create
   end
 
   private def create_worker_instance(index : Int32, node_pool, placement_group : Hetzner::PlacementGroup?) : Hetzner::Instance::Create
+    legacy_instance_type = node_pool.legacy_instance_type
     instance_type = node_pool.instance_type
 
-    node_name = if settings.include_instance_type_in_instance_name
+    legacy_instance_type_name_part = legacy_instance_type.blank? ? "" : "#{legacy_instance_type}-"
+
+    legacy_instance_name = if settings.include_instance_type_in_instance_name
+      "#{settings.cluster_name}-#{legacy_instance_type_name_part}#{instance_type}-pool-#{node_pool.name}-worker#{index + 1}"
+    else
+      "#{settings.cluster_name}-#{legacy_instance_type_name_part}pool-#{node_pool.name}-worker#{index + 1}"
+    end
+
+    instance_name = if settings.include_instance_type_in_instance_name
       "#{settings.cluster_name}-#{instance_type}-pool-#{node_pool.name}-worker#{index + 1}"
     else
       "#{settings.cluster_name}-pool-#{node_pool.name}-worker#{index + 1}"
@@ -241,7 +260,8 @@ class Cluster::Create
       settings: settings,
       hetzner_client: hetzner_client,
       mutex: mutex,
-      instance_name: node_name,
+      legacy_instance_name: legacy_instance_name,
+      instance_name: instance_name,
       instance_type: instance_type,
       image: image,
       location: node_pool.location,

--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -127,23 +127,17 @@ class Cluster::Create
     end
   end
 
+  private def build_master_instance_name(instance_type, worker_index, include_instance_type) : String
+    instance_type_part = include_instance_type ? "#{instance_type}-" : ""
+    "#{settings.cluster_name}-#{instance_type_part}master#{worker_index}"
+  end
+
   private def create_master_instance(index : Int32, placement_group : Hetzner::PlacementGroup?) : Hetzner::Instance::Create
     legacy_instance_type = settings.masters_pool.legacy_instance_type
     instance_type = settings.masters_pool.instance_type
 
-    legacy_instance_type_name_part = legacy_instance_type.blank? ? "" : "#{legacy_instance_type}-"
-
-    legacy_instance_name = if settings.include_instance_type_in_instance_name
-      "#{settings.cluster_name}-#{legacy_instance_type_name_part}#{instance_type}-master#{index + 1}"
-    else
-      "#{settings.cluster_name}-#{legacy_instance_type_name_part}master#{index + 1}"
-    end
-
-    instance_name = if settings.include_instance_type_in_instance_name
-      "#{settings.cluster_name}-#{instance_type}-master#{index + 1}"
-    else
-      "#{settings.cluster_name}-master#{index + 1}"
-    end
+    legacy_instance_name = build_master_instance_name(legacy_instance_type, index + 1, true)
+    instance_name = build_master_instance_name(instance_type, index + 1, settings.include_instance_type_in_instance_name)
 
     image = settings.masters_pool.image || settings.image
     additional_packages = settings.masters_pool.additional_packages || settings.additional_packages
@@ -234,23 +228,17 @@ class Cluster::Create
     created_placement_groups
   end
 
+  private def build_worker_instance_name(instance_type, pool_name, worker_index, include_instance_type) : String
+    instance_type_part = include_instance_type ? "#{instance_type}-" : ""
+    "#{settings.cluster_name}-#{instance_type_part}pool-#{pool_name}-worker#{worker_index}"
+  end
+
   private def create_worker_instance(index : Int32, node_pool, placement_group : Hetzner::PlacementGroup?) : Hetzner::Instance::Create
     legacy_instance_type = node_pool.legacy_instance_type
     instance_type = node_pool.instance_type
 
-    legacy_instance_type_name_part = legacy_instance_type.blank? ? "" : "#{legacy_instance_type}-"
-
-    legacy_instance_name = if settings.include_instance_type_in_instance_name
-      "#{settings.cluster_name}-#{legacy_instance_type_name_part}#{instance_type}-pool-#{node_pool.name}-worker#{index + 1}"
-    else
-      "#{settings.cluster_name}-#{legacy_instance_type_name_part}pool-#{node_pool.name}-worker#{index + 1}"
-    end
-
-    instance_name = if settings.include_instance_type_in_instance_name
-      "#{settings.cluster_name}-#{instance_type}-pool-#{node_pool.name}-worker#{index + 1}"
-    else
-      "#{settings.cluster_name}-pool-#{node_pool.name}-worker#{index + 1}"
-    end
+    legacy_instance_name = build_worker_instance_name(legacy_instance_type, node_pool.name, index + 1, true)
+    instance_name = build_worker_instance_name(instance_type, node_pool.name, index + 1, settings.include_instance_type_in_instance_name)
 
     image = node_pool.image || settings.image
     additional_packages = node_pool.additional_packages || settings.additional_packages

--- a/src/configuration/node_pool.cr
+++ b/src/configuration/node_pool.cr
@@ -8,6 +8,7 @@ class Configuration::NodePool
   include YAML::Serializable
 
   property name : String?
+  property legacy_instance_type : String = ""
   property instance_type : String
   property location : String
   property image : String | Int64 | Nil

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -335,11 +335,17 @@ class Hetzner::Instance::Create
     instance = instance_finder.run
   end
 
+  private def has_legacy_instance_name?
+    legacy_instance_name != instance_name
+  end
+
+  private def find_instance_by_name(name)
+    find_instance_with_kubectl(name) || find_instance_via_api(name)
+  end
+
   private def find_instance
-    instance = find_instance_with_kubectl(legacy_instance_name) if legacy_instance_name != instance_name
-    instance ||= find_instance_with_kubectl(instance_name)
-    instance ||= find_instance_via_api(legacy_instance_name) if legacy_instance_name != instance_name
-    instance ||= find_instance_via_api(instance_name)
+    instance = find_instance_by_name(legacy_instance_name) if has_legacy_instance_name?
+    instance ||= find_instance_by_name(instance_name)
 
     instance
   end


### PR DESCRIPTION
This update lets different types of instances coexist within the same node pool. This will make it easier for older clusters to transition from the 1.1.5 naming system, which included instance type in the name, to the newer 2.x naming scheme that doesn’t include this detail.