### PR TITLE
Fix network_zone_by_location

### DIFF
--- a/src/configuration/settings/node_pool/location.cr
+++ b/src/configuration/settings/node_pool/location.cr
@@ -14,11 +14,11 @@ class Configuration::Settings::NodePool::Location
   def self.network_zone_by_location(location)
     case location
     when "ash"
-      "ash"
+      "us-west"
     when "hil"
-      "hil"
+      "us-east"
     when "sin"
-      "sin"
+      "ap-southeast"
     else
       "eu-central"
     end


### PR DESCRIPTION
`network_zone_by_location` returns the incorrect `network_zone` for `ash`, `hil` and `sin`, preventing creation of new networks

```
[Configuration] Validating configuration...
[Configuration] ...configuration seems valid.
[Private Network] Creating private network...
[Private Network] Failed to create private network: {
    "error": {
        "code": "invalid_input",
        "message": "invalid input in field 'subnets[0].network_zone'",
        "details": {
            "fields": [
                {
                    "messages": [
                        "network zone does not exist"
                    ],
                    "name": "subnets[0].network_zone"
                }
            ]
        }
    }
}
```

See [issue](https://github.com/vitobotta/hetzner-k3s/issues/532) for more details 

I tested my change with docker compose
```
2a76b9c49fd2:/home/app/hetzner-k3s# crystal run ./src/hetzner-k3s.cr -- create --config cluster_config.yaml
 _          _                            _    _____
| |__   ___| |_ _____ __   ___ _ __     | | _|___ / ___
| '_ \ / _ \ __|_  / '_ \ / _ \ '__|____| |/ / |_ \/ __|
| | | |  __/ |_ / /| | | |  __/ | |_____|   < ___) \__ \
|_| |_|\___|\__/___|_| |_|\___|_|       |_|\_\____/|___/

Version: 2.2.4

[Configuration] Validating configuration...
[Configuration] ...configuration seems valid.
[Private Network] Creating private network...
[Private Network] ...private network created
[Placement groups] Creating placement group unopago-cluster-masters...
[Placement groups] ...placement group unopago-cluster-masters created
[Placement groups] Creating placement group unopago-cluster-small-1...
[Placement groups] ...placement group unopago-cluster-small-1 created
...
```

