### PR TITLE
fix: allow udp per default on nodeportrange in firewall

### DIFF
--- a/src/hetzner/firewall/create.cr
+++ b/src/hetzner/firewall/create.cr
@@ -76,9 +76,20 @@ class Hetzner::Firewall::Create
         :destination_ips => [] of String
       },
       {
-        :description => "Node port range",
+        :description => "Node port range TCP",
         :direction => "in",
         :protocol =>  "tcp",
+        :port => "30000-32767",
+        :source_ips => [
+          "0.0.0.0/0",
+          "::/0"
+        ],
+        :destination_ips => [] of String
+      },
+      {
+        :description => "Node port range UDP",
+        :direction => "in",
+        :protocol =>  "udp",
         :port => "30000-32767",
         :source_ips => [
           "0.0.0.0/0",


### PR DESCRIPTION
Hi!
Per default, a firewall rule `Node port range` is created which allows  `TCP` on the range `30000-32767`. While this totally makes sense to me, I currently don't see any dedicated reason why only TCP should be allowed per default and not UDP. This might be especially relevant as to my knowledge hetzner LB's currently don't support UDP ( see https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/252 ) .

Thank you for considering this change!