### PR TITLE
Set up mkdocs for documentation site

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,28 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - run: pip install mkdocs-material
+
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,7 +3,11 @@ name: Publish docs
 on:
   push:
     branches:
-      - "*"
+      - main
+    paths:
+      - ".github/workflows/publish-docs.yml"
+      - "docs/**/*"
+      - "mkdocs.yml"
 
 permissions:
   contents: write

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,8 @@ RUN apk update \
     libxml2-static openssl-dev openssl-libs-static tzdata yaml-static zlib-static xz-static \
     make git autoconf automake libtool patch libssh2-static libssh2-dev crystal shards \
     curl docker zsh bash openssl k9s shadow go envsubst util-linux \
-    gcc g++ libc-dev libxml2-dev openssl-dev yaml-dev zlib-dev crystal openssh-client jq
+    gcc g++ libc-dev libxml2-dev openssl-dev yaml-dev zlib-dev crystal openssh-client jq \
+    python3 py3-pip
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')/kubectl" && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 
@@ -29,6 +30,8 @@ ENV GOPATH=/root/go
 RUN mkdir -p $GOPATH/bin
 
 RUN go install github.com/stern/stern@v1.30.0
+
+RUN pip install mkdocs-material --break-system-packages
 
 SHELL ["/bin/zsh", "-c"]
 

--- a/docs/Recommendations.md
+++ b/docs/Recommendations.md
@@ -10,6 +10,7 @@ However, for larger clusters, the default setup—which uses Hetzner’s private
 2. Flannel performs well for smaller clusters, but its performance declines with clusters of several hundred or thousands of nodes. For better scalability, I recommend switching to Cilium as your CNI, as it handles large clusters efficiently.
 
 Additional notes:
+
 - If you disable the private network due to the node limit, encryption will be applied at the CNI level to secure communication between nodes over the public network.
 - If you prefer a CNI other than Cilium or Flannel (e.g., Calico), you can disable automatic CNI setup and install your preferred CNI manually. We may add support for more CNIs in future releases.
 - Starting with v2.0.0, you can use an external SQL datastore like Postgres instead of the built-in etcd for the Kubernetes API. This can also help with scaling larger clusters.

--- a/docs/Setting up a cluster.md
+++ b/docs/Setting up a cluster.md
@@ -246,11 +246,13 @@ Yes, you can use MetalLB with floating IPs in Hetzner Cloud, but I wouldn’t re
 ### 2. How do I create and push Docker images to a repository, and how can Kubernetes work with these images? (GitLab example)
 
 On the machine where you create the image:
+
 - Start by logging in to the Docker registry: `docker login registry.gitlab.com`.
 - Build the Docker image: `docker build -t registry.gitlab.com/COMPANY_NAME/REPO_NAME:IMAGE_NAME -f /some/path/to/Dockerfile .`.
 - Push the image to the registry: `docker push registry.gitlab.com/COMPANY_NAME/REPO_NAME:IMAGE_NAME`.
 
 On the machine running Kubernetes:
+
 - Generate a secret to allow Kubernetes to access the images: `kubectl create secret docker-registry gitlabcreds --docker-server=https://registry.gitlab.com --docker-username=MYUSER --docker-password=MYPWD --docker-email=MYEMAIL -n NAMESPACE_OF_YOUR_APP -o yaml > docker-secret.yaml`.
 - Apply the secret: `kubectl apply -f docker-secret.yaml -n NAMESPACE_OF_YOUR_APP`.
 
@@ -263,6 +265,7 @@ First, install the metrics-server from this GitHub repository: https://github.co
 There are two types of "ingress" to understand: `Ingress Controller` and `Ingress Resources`.
 
 In the case of Nginx:
+
 - The `Ingress Controller` is Nginx itself (defined as `kind: Ingress`), while `Ingress Resources` are services (defined as `kind: Service`).
 - The `Ingress Controller` has various annotations (rules). You can use these annotations in `kind: Ingress` to make them "global" or in `kind: Service` to make them "local" (specific to that service).
 - The `Ingress Controller` consists of a Pod and a Service. The Pod runs the Controller, which continuously monitors the /ingresses endpoint in your cluster’s API server for updates to available `Ingress Resources`.
@@ -301,5 +304,6 @@ kubectl get all -A` does not include "ingress", so use `kubectl get ing -A
 ```
 
 ## Useful Links
-Cheat Sheet - https://kubernetes.io/docs/reference/kubectl/cheatsheet/
-A visual guide on troubleshooting Kubernetes deployments - https://learnk8s.io/troubleshooting-deployments
+
+- [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+- [A visual guide on troubleshooting Kubernetes deployments](https://learnk8s.io/troubleshooting-deployments)

--- a/docs/Upgrading_a_cluster_from_1x_to_2x.md
+++ b/docs/Upgrading_a_cluster_from_1x_to_2x.md
@@ -35,6 +35,7 @@ Replace one master at a time (unless your cluster has a load balancer for the Ku
 - [ ] Drain and delete the master using both kubectl and the Hetzner console (or the `hcloud` CLI) to remove the actual instance.
 - [ ] Rerun the `create` command to recreate the master with the new instance type. Wait for it to join the control plane and reach the "ready" status.
 - [ ] SSH into each master and verify that the etcd members are updated and in sync:
+
 ```bash
 sudo apt-get update
 sudo apt-get install etcd-client

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+<h1 align="center">hetzner-k3s</h1>
+
+<p align="center">
+  <img src="https://github.com/vitobotta/hetzner-k3s/raw/main/logo.png" alt="hetzner-k3s logo" width="200" height="200" style="margin-left: auto;">
+</p>
+
+<h3 align="center">The simplest and quickest way to set up<br/>production-ready Kubernetes clusters on Hetzner Cloud.</h3>
+
+## What is this?
+
+This is a CLI tool designed to make it incredibly fast and easy to create and manage Kubernetes clusters on [Hetzner Cloud](https://www.hetzner.com/cloud) using [k3s](https://k3s.io/), a lightweight Kubernetes distribution from [Rancher](https://rancher.com/). In a test run, I created a **500**-node highly available cluster (3 masters, 497 worker nodes) in just **under 11 minutes** - though this was with only the public network, as private networks are limited to 100 instances per network. I think this might be a world record!
+
+Hetzner Cloud is an awesome cloud provider that offers excellent service with the best performance-to-cost ratio available. They have data centers in Europe, USA and Singapore, making it a versatile choice.
+
+k3s is my go-to Kubernetes distribution because it's lightweight, using far less memory and CPU, which leaves more resources for your workloads. It is also incredibly fast to deploy and upgrade because, thanks to being a single binary.
+
+With `hetzner-k3s`, setting up a highly available k3s cluster with 3 master nodes and 3 worker nodes takes only **2-3 minutes**. This includes:
+
+- Creating all the necessary infrastructure resources (instances, placement groups, load balancer, private network, and firewall).
+- Deploying k3s to the nodes.
+- Installing the [Hetzner Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) to provision load balancers immediately.
+- installing the [Hetzner CSI Driver](https://github.com/hetznercloud/csi-driver) to handle persistent volumes using Hetzner's block storage.
+- Installing the [Rancher System Upgrade Controller](https://github.com/rancher/system-upgrade-controller) to simplify and speed up k3s version upgrades.
+- Installing the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler) to enable autoscaling of node pools.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: hetzner-k3s documentation
+repo_name: vitobotta/hetzner-k3s
+repo_url: https://github.com/vitobotta/hetzner-k3s
+theme:
+  name: material
+  features:
+    - content.tooltips
+    - content.code.annotate
+    - content.code.copy
+    - navigation.expand
+    - navigation.indexes
+    - navigation.sections
+    - search.highlight
+    - search.suggest
+  icon:
+    logo: material/book-open
+  palette: 
+    scheme: slate
+plugins:
+  - search
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+nav:
+  - Home: index.md
+  - Installation.md
+  - Creating_a_cluster.md
+  - Masters_in_different_locations.md
+  - Private_clusters_with_public_network_interface_disabled.md
+  - Upgrading_a_cluster_from_1x_to_2x.md
+  - Setting up a cluster.md
+  - Recommendations.md
+  - Maintenance.md
+  - Deleting_a_cluster.md
+  - Load_balancers.md
+  - Storage.md
+  - Troubleshooting.md
+  - Contributing_and_support.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.tasklist
 nav:
   - Home: index.md
   - Installation.md


### PR DESCRIPTION
As I am sinking into hetzner-k3s, I found navigating/searching the documentation via github itself pretty annoying, so I figured I could bootstrap docs site quickly using mkdocs

Here's how it looks: https://vvarp.github.io/hetzner-k3s/

What's done:

- basic documentation homepage, which consists of first few paragraphs of a README
- mkdocs configuration good enough to get started (with search and code highlighting enabled)
- navigation mapped to docs order as it is currently in README
- reformatted few docs to render properly in mkdocs
- added `mkdocs` to devcontainer
- github action to deploy to github pages when documentation gets updated

If you are okay to merge this, you might want to check repository configuration as mentioned at https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions since by default github pages publishing might be disabled

Thanks!