### PR TITLE
fix cloud-init schema validation error when {{ growpart_str }} is not empty

### DIFF
--- a/templates/cloud_init.yaml
+++ b/templates/cloud_init.yaml
@@ -1,10 +1,10 @@
 #cloud-config
 preserve_hostname: true
 
+{{ growpart_str }}
+
 write_files:
 {{ eth1_str }}
-
-{{ growpart_str }}
 
 - path: /etc/systemd/system/ssh.socket.d/listen.conf
   content: |


### PR DESCRIPTION
{{ growpart_str }}, when not empty, breaks cloud-init schema validation.

This is easily fixed by moving {{ growpart_str }} up in the template file.
