### PR TITLE
Fix output interface in nated setup

### DIFF
--- a/docs/Private_clusters_with_public_network_interface_disabled.md
+++ b/docs/Private_clusters_with_public_network_interface_disabled.md
@@ -30,7 +30,7 @@ The TL;DR is this:
 auto enp7s0
 iface enp7s0 inet dhcp
     post-up echo 1 > /proc/sys/net/ipv4/ip_forward
-    post-up iptables -t nat -A POSTROUTING -s '10.0.0.0/16' -o enp7s0 -j MASQUERADE
+    post-up iptables -t nat -A POSTROUTING -s '10.0.0.0/16' -o eth0 -j MASQUERADE
 ```
 
 Replace `10.0.0.0/16` with your actual subnet if it's different. Also, make sure to use the correct name for your private network interface if `enp7s0` isn't right—find this with the `ifconfig` command.


### PR DESCRIPTION
The output interface for iptables must be the public interface. It can't be the same interface, and usually on hetzner cloud the public one is eth0.

Related to [#541](https://github.com/vitobotta/hetzner-k3s/issues/541)