### PR TITLE
Correct error message for network encryption with disabled private network

### DIFF
--- a/src/configuration/networking_components/cni.cr
+++ b/src/configuration/networking_components/cni.cr
@@ -18,7 +18,7 @@ class Configuration::NetworkingComponents::CNI
     return unless enabled
 
     if !encryption && !private_network.enabled
-      errors << "CNI encryption must be enabled when private networking is enabled"
+      errors << "CNI encryption must be enabled when private networking is disabled"
     end
 
     unless ["flannel", "cilium"].includes?(mode)


### PR DESCRIPTION
Was spelunking the code and found this minor mistake.