### PR TITLE
change the order of commands executed in cloud-init runcmd, post_create_commands to be always run first

### DIFF
--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -301,7 +301,7 @@ class Hetzner::Instance::Create
 
     formatted_additional_commands = format_additional_commands(additional_post_create_commands)
 
-    combined_commands = [post_create_commands, init_commands, formatted_additional_commands].flatten
+    combined_commands = [formatted_additional_commands, post_create_commands, init_commands].flatten
 
     "- #{combined_commands.join("\n- ")}"
   end


### PR DESCRIPTION
This resolves the issue with cluster-autoscaler nodes, as the custom network must be applied first, followed by all other commands.