### PR TITLE
docs: add Fedora snippet to Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -48,6 +48,14 @@ export OPENSSL_CONF=/dev/null
 export OPENSSL_MODULES=/dev/null
 ```
 
+For example, you can define a function replacing `hetzner-k3s` in your `.bashrc` or `.zshrc`:
+
+```bash
+hetzner-k3s() {
+    OPENSSL_CONF=/dev/null OPENSSL_MODULES=/dev/null command hetzner-k3s "$@"
+}
+```
+
 #### amd64
 ```bash
 wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.3.2/hetzner-k3s-linux-amd64


### PR DESCRIPTION
This commit suggests users to define a function in their .bashrc or .zshrc to set the correct OPENSSL environment variables on Fedora.

I tested it on my machine, it works well and seems to pass the arguments correctly:

<img width="1016" height="274" alt="image" src="https://github.com/user-attachments/assets/c80be827-8c6b-46ef-b932-70816b177c50" />
