### PR TITLE
Add pagination support for Server Types API

### DIFF
--- a/src/hetzner/instance_types_list.cr
+++ b/src/hetzner/instance_types_list.cr
@@ -4,4 +4,22 @@ class Hetzner::InstanceTypesList
   include JSON::Serializable
 
   property server_types : Array(Hetzner::InstanceType)
+  property meta : Hetzner::Meta?
+end
+
+class Hetzner::Meta
+  include JSON::Serializable
+
+  property pagination : Hetzner::Pagination?
+end
+
+class Hetzner::Pagination
+  include JSON::Serializable
+
+  property page : Int32
+  property per_page : Int32
+  property total_entries : Int32
+  property last_page : Int32
+  property next_page : Int32?
+  property previous_page : Int32?
 end


### PR DESCRIPTION
On Oct 15 2025 Hetzner announced restructurization of their pricing plans and introduced bunch of new server / instance types. 

hetzner-k3s can't create pools of some instance types now like `cx33`:

```js
[Configuration] Validating configuration...
[Configuration] Some information in the configuration file requires your attention, aborting.
[Configuration]  - masters node pool has an invalid instance type
```

See issue #671.

The API for resolving server types now returns 2 pages of information:

```bash
curl \
  -H "Authorization: Bearer $API_TOKEN" \
  "https://api.hetzner.cloud/v1/server_types"
```

API Docs: https://docs.hetzner.cloud/reference/cloud#server-types

It's now a paginated response:

```json
"meta": {
  "pagination": {
   "last_page": 2,
   "next_page": 2,
   "page": 1,
   "per_page": 25,
   "previous_page": null,
   "total_entries": 29
  }
```

This PR adds support for iterating all pages of Server Type API response and collecting instance types from that.

Tested locally via:

```bash
brew install crystal
shards install --without-development
crystal build src/hetzner-k3s.cr --release
chmod +x hetzner-k3s

hetzner-k3s create --config test-cluster-with-instance_type-cx33.yaml
 _          _                            _    _____
| |__   ___| |_ _____ __   ___ _ __     | | _|___ / ___
| '_ \ / _ \ __|_  / '_ \ / _ \ '__|____| |/ / |_ \/ __|
| | | |  __/ |_ / /| | | |  __/ | |_____|   < ___) \__ \
|_| |_|\___|\__/___|_| |_|\___|_|       |_|\_\____/|___/

Version: 2.4.2

[Configuration] Validating configuration...
[Configuration] ...configuration seems valid.
[SSH key] Creating SSH key...
[SSH key] ...SSH key created
[Instance xxx-master1] Creating instance xxx-master1 (attempt 1)...
[Instance xxx-master1] Instance status: initializing
[Instance xxx-master1] Powering on instance (attempt 1)
[Instance xxx-master1] Waiting for instance to be powered on...
…
[System Upgrade Controller] ...System Upgrade Controller installed
[Control plane] Switched to context "xxx-master1".
```

Apologies if my Crystal code isn't very idiomatic, first time I did anything in this language 😅 

Closes #671.