### PR TITLE
Bump outdated version number in docs

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -27,14 +27,14 @@ First, install these dependencies:
 
 ##### Apple Silicon / ARM
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.1/hetzner-k3s-macos-arm64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.2/hetzner-k3s-macos-arm64
 chmod +x hetzner-k3s-macos-arm64
 sudo mv hetzner-k3s-macos-arm64 /usr/local/bin/hetzner-k3s
 ```
 
 ##### Intel / x86
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.1/hetzner-k3s-macos-amd64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.2/hetzner-k3s-macos-amd64
 chmod +x hetzner-k3s-macos-amd64
 sudo mv hetzner-k3s-macos-amd64 /usr/local/bin/hetzner-k3s
 ```
@@ -58,14 +58,14 @@ hetzner-k3s() {
 
 #### amd64
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.1/hetzner-k3s-linux-amd64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.2/hetzner-k3s-linux-amd64
 chmod +x hetzner-k3s-linux-amd64
 sudo mv hetzner-k3s-linux-amd64 /usr/local/bin/hetzner-k3s
 ```
 
 #### arm
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.1/hetzner-k3s-linux-arm64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.2/hetzner-k3s-linux-arm64
 chmod +x hetzner-k3s-linux-arm64
 sudo mv hetzner-k3s-linux-arm64 /usr/local/bin/hetzner-k3s
 ```


### PR DESCRIPTION
I copy-pasted the installation instructions which use 2.4.1. This version doesn't support pagination so the tool is unaware of recently added server types (see #672). Only after diving into the source I code I discovered I'm running an outdated version.

Perhaps we can automate updating installation instructions by using placeholders in the Markdown or search/replace in the release workflow. Let me know what would be your preferred approach, happy to contribute.