### PR TITLE
feat(ip-query-server): lb of masters added to firewall use_local_firewall

### DIFF
--- a/ip-query-server/app.rb
+++ b/ip-query-server/app.rb
@@ -8,9 +8,9 @@ class HetznerApp < Sinatra::Base
   # Configuration
   configure do
     set :cache_duration, 30 # seconds
-    set :per_page, 50 # Number of servers to fetch per page
+    set :per_page, 50 # Number of servers/load balancers to fetch per page
     set :host_authorization, { permitted_hosts: [] }
-    set :valid_roles, ['master', 'worker']
+    set :valid_roles, ['master', 'worker', 'loadbalancer']
   end
 
   # Cache storage
@@ -83,8 +83,8 @@ class HetznerApp < Sinatra::Base
     result.to_json
   end
 
-  def fetch_hetzner_page(token, page)
-    uri = URI.parse("https://api.hetzner.cloud/v1/servers?page=#{page}&per_page=#{settings.per_page}")
+  def fetch_hetzner_page(token, page, resource_type = 'servers')
+    uri = URI.parse("https://api.hetzner.cloud/v1/#{resource_type}?page=#{page}&per_page=#{settings.per_page}")
     request = Net::HTTP::Get.new(uri)
     request['Authorization'] = "Bearer #{token}"
     request['Content-Type'] = 'application/json'
@@ -100,11 +100,69 @@ class HetznerApp < Sinatra::Base
     end
   end
 
+  def fetch_load_balancer_ips(token, master_server_ids)
+    lb_ips = []
+    page = 1
+
+    # Fetch first page
+    first_page_data = fetch_hetzner_page(token, page, 'load_balancers')
+    return [] if error?(first_page_data) || !first_page_data['load_balancers']
+
+    # Extract IPs only from LBs that target master nodes
+    # This filters out Istio ingress LBs and other unrelated load balancers
+    first_page_data['load_balancers'].each do |lb|
+      if lb_targets_masters?(lb, master_server_ids) && lb['public_net'] && lb['public_net']['ipv4'] && lb['public_net']['ipv4']['ip']
+        lb_ips << lb['public_net']['ipv4']['ip']
+      end
+    end
+
+    # Calculate total pages
+    meta = first_page_data['meta']
+    total_pages = if meta && meta['pagination']
+      (meta['pagination']['total_entries'].to_f / settings.per_page).ceil
+    else
+      1
+    end
+
+    # Fetch remaining pages if any
+    (2..total_pages).each do |current_page|
+      page_data = fetch_hetzner_page(token, current_page, 'load_balancers')
+      next if error?(page_data) || !page_data['load_balancers']
+
+      page_data['load_balancers'].each do |lb|
+        if lb_targets_masters?(lb, master_server_ids) && lb['public_net'] && lb['public_net']['ipv4'] && lb['public_net']['ipv4']['ip']
+          lb_ips << lb['public_net']['ipv4']['ip']
+        end
+      end
+    end
+
+    lb_ips
+  end
+
+  # Check if a load balancer targets any master nodes
+  def lb_targets_masters?(lb, master_server_ids)
+    return false if master_server_ids.empty?
+    return false unless lb['targets']
+
+    lb['targets'].any? do |target|
+      if target['type'] == 'server' && target['server']
+        master_server_ids.include?(target['server']['id'])
+      elsif target['type'] == 'label_selector'
+        # Label selector targeting masters (e.g., role=master)
+        target['label_selector'] && target['label_selector']['selector'] =~ /role=master/
+      else
+        false
+      end
+    end
+  end
+
   def fetch_and_cache_all_ips(token)
     # Initialize IP collections for all categories
     all_ips = []
     master_ips = []
     worker_ips = []
+    master_server_ids = []
+    lb_ips = []
     page = 1
 
     # Fetch first page to get pagination info
@@ -112,7 +170,7 @@ class HetznerApp < Sinatra::Base
     return first_page_data if error?(first_page_data)
 
     # Extract IPs from first page
-    extract_and_categorize_ips(first_page_data, all_ips, master_ips, worker_ips)
+    extract_and_categorize_ips(first_page_data, all_ips, master_ips, worker_ips, master_server_ids)
 
     # Calculate total pages
     total_pages = calculate_total_pages(first_page_data)
@@ -121,17 +179,22 @@ class HetznerApp < Sinatra::Base
     (2..total_pages).each do |current_page|
       page_data = fetch_hetzner_page(token, current_page)
       return page_data if error?(page_data)
-      extract_and_categorize_ips(page_data, all_ips, master_ips, worker_ips)
+      extract_and_categorize_ips(page_data, all_ips, master_ips, worker_ips, master_server_ids)
     end
 
-    # Update cache for all three sets
-    update_cache(token, all_ips, master_ips, worker_ips)
+    # Also fetch load balancer IPs that target master nodes and add them to all_ips
+    # This is critical for LB health checks when use_local_firewall: true
+    lb_ips = fetch_load_balancer_ips(token, master_server_ids)
+    all_ips.concat(lb_ips)
+
+    # Update cache for all sets (including loadbalancer)
+    update_cache(token, all_ips, master_ips, worker_ips, lb_ips)
 
     # Return the complete set of IPs
     all_ips
   end
 
-  def extract_and_categorize_ips(page_data, all_ips, master_ips, worker_ips)
+  def extract_and_categorize_ips(page_data, all_ips, master_ips, worker_ips, master_server_ids)
     page_data['servers'].each do |server|
       ip = server['public_net']['ipv4']['ip']
       all_ips << ip
@@ -139,6 +202,7 @@ class HetznerApp < Sinatra::Base
       # Also add to role-specific collections
       if server['labels'] && server['labels']['role'] == 'master'
         master_ips << ip
+        master_server_ids << server['id']
       elsif server['labels'] && server['labels']['role'] == 'worker'
         worker_ips << ip
       end
@@ -154,11 +218,12 @@ class HetznerApp < Sinatra::Base
     end
   end
 
-  def update_cache(token, all_ips, master_ips, worker_ips)
+  def update_cache(token, all_ips, master_ips, worker_ips, lb_ips = [])
     # Cache each set with its own key
     @@ip_cache["#{token}:all"] = all_ips
     @@ip_cache["#{token}:master"] = master_ips
     @@ip_cache["#{token}:worker"] = worker_ips
+    @@ip_cache["#{token}:loadbalancer"] = lb_ips
 
     # Use a single last fetch time for the token
     @@last_fetch_time[token] = Time.now


### PR DESCRIPTION
feat(ip-query-server): lb of masters added to firewall when private_network false and create_load_balancer_for_the_kubernetes_api: true, use_local_firewall: true


Modified ip-query-server/app.rb to:
    - Fetch load balancer IPs from Hetzner API (/v1/load_balancers)
    - Filter to only include LBs whose targets include master nodes (by checking server IDs or label selectors with role=master)
    - Include LB IPs in the "all" IPs response
    - Added new ?role=loadbalancer filter option


How it filters LBs:

The code checks if a load balancer targets master nodes by:
  1. Checking if target.type == 'server' and the server ID matches a master server ID
  2. Checking if target.type == 'label_selector' and the selector contains role=master

This ensures that Istio ingress LBs and other unrelated load balancers are excluded - only the K8s API load balancer (which targets the 3 master nodes) is included.


Without this I could not connect to my cluster from my machine using kubectl
