### PR TITLE
Fix macOS CI by upgrading image from macos-13 → macos-14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs_on_tag: macos-13
+          - runs_on_tag: macos-14
             binary_os_suffix: macos
             binary_arch_suffix: amd64
           - runs_on_tag: macos-14


### PR DESCRIPTION
macOS CI recently started to fail because GitHub stopped supporting macos-13 images:

>The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.

Example of a failed build from main branch: https://github.com/vitobotta/hetzner-k3s/actions/runs/20285977184/job/58259622212

---

PR upgrades macos-13 build to macos-14 as minimal allowed version bump, this might break macos-13 compatibility for users in future if code starts to link against macOS 14+ specific system calls.