### PR TITLE
add option to create and set-up a cluster through their private-IPs

### DIFF
--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -19,6 +19,7 @@ networking:
   ssh:
     port: 22
     use_agent: false # set to true if your key has a passphrase
+    use_private_ip: false # set to true to connect to nodes via their private IPs
     public_key_path: "~/.ssh/id_ed25519.pub"
     private_key_path: "~/.ssh/id_ed25519"
   allowed_networks:
@@ -243,6 +244,8 @@ To create the cluster run:
 hetzner-k3s create --config cluster_config.yaml | tee create.log
 ```
 
+If you need to bypass the validation that your current IP is included in the allowed SSH/API networks, add `--skip-current-ip-validation`.
+
 This process will take a few minutes, depending on how many master and worker nodes you have.
 
 ### Disabling public IPs (IPv4 or IPv6 or both) on nodes
@@ -371,4 +374,3 @@ The `create` command can be run multiple times with the same configuration witho
 eval "$(ssh-agent -s)"
 ssh-add --apple-use-keychain ~/.ssh/<private key>
 ```
-

--- a/docs/Setting_up_a_cluster.md
+++ b/docs/Setting_up_a_cluster.md
@@ -32,6 +32,7 @@ networking:
   ssh:
     port: 22
     use_agent: false
+    use_private_ip: false
     public_key_path: "~/.ssh/id_rsa.pub"
     private_key_path: "~/.ssh/id_rsa"
   allowed_networks:

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -64,7 +64,7 @@ This will provide more detailed output, which can help you identify the root of 
 
 **Symptoms**: Cluster creation hangs after nodes are created. SSH connection times out when trying to connect to a private IP address.
 
-**Note**: The tool currently does not support IPv6-only public network configuration. When you disable IPv4 (`public_network.ipv4: false`), you must run `hetzner-k3s` from a machine that has access to the same private network, either directly or through a VPN. Otherwise, the tool will attempt to use the private IP addresses for SSH connections and fail.
+**Note**: The tool currently does not support IPv6-only public network configuration. When you disable IPv4 (`public_network.ipv4: false`) or enable `networking.ssh.use_private_ip: true`, you must run `hetzner-k3s` from a machine that has access to the same private network, either directly or through a VPN. Otherwise, the tool will attempt to use private IP addresses for SSH/API connections and fail.
 
 ### Load Balancer Issues
 

--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -12,7 +12,13 @@ class Cluster::Create
   private getter hetzner_client : Hetzner::Client { configuration.hetzner_client }
   private getter settings : Configuration::Main { configuration.settings }
   private getter autoscaling_worker_node_pools : Array(Configuration::Models::WorkerNodePool) { settings.worker_node_pools.select(&.autoscaling_enabled) }
-  private getter ssh_client : Util::SSH { Util::SSH.new(settings.networking.ssh.private_key_path, settings.networking.ssh.public_key_path) }
+  private getter ssh_client : Util::SSH do
+    Util::SSH.new(
+      settings.networking.ssh.private_key_path,
+      settings.networking.ssh.public_key_path,
+      settings.networking.ssh.use_private_ip
+    )
+  end
   private getter network : Hetzner::Network?
   private getter ssh_key : Hetzner::SSHKey
   private getter load_balancer : Hetzner::LoadBalancer?

--- a/src/cluster/run.cr
+++ b/src/cluster/run.cr
@@ -139,8 +139,9 @@ class Cluster::Run
 
     puts "Nodes that will be affected:"
     instances.each do |instance|
-      if instance.host_ip_address
-        puts "  - #{instance.name} (#{instance.host_ip_address})"
+      host_ip_address = instance.host_ip_address(settings.networking.ssh.use_private_ip)
+      if host_ip_address
+        puts "  - #{instance.name} (#{host_ip_address})"
       else
         puts "  - #{instance.name} (no IP address - will be skipped)"
       end
@@ -154,8 +155,9 @@ class Cluster::Run
     puts
 
     puts "Node that will be affected:"
-    if instance.host_ip_address
-      puts "  - #{instance.name} (#{instance.host_ip_address})"
+    host_ip_address = instance.host_ip_address(settings.networking.ssh.use_private_ip)
+    if host_ip_address
+      puts "  - #{instance.name} (#{host_ip_address})"
     else
       puts "  - #{instance.name} (no IP address - will be skipped)"
     end
@@ -177,7 +179,8 @@ class Cluster::Run
   private def setup_ssh_connection
     Util::SSH.new(
       settings.networking.ssh.private_key_path,
-      settings.networking.ssh.public_key_path
+      settings.networking.ssh.public_key_path,
+      settings.networking.ssh.use_private_ip
     )
   end
 
@@ -201,8 +204,9 @@ class Cluster::Run
   private def execute_on_single_instance(ssh : Util::SSH, instance, action_type : String, &block : Util::SSH, Hetzner::Instance -> String)
     output_lines = [] of String
 
-    if instance.host_ip_address
-      output_lines << "=== Instance: #{instance.name} (#{instance.host_ip_address}) ==="
+    host_ip_address = instance.host_ip_address(settings.networking.ssh.use_private_ip)
+    if host_ip_address
+      output_lines << "=== Instance: #{instance.name} (#{host_ip_address}) ==="
 
       begin
         success_message = block.call(ssh, instance)

--- a/src/configuration/loader.cr
+++ b/src/configuration/loader.cr
@@ -68,10 +68,11 @@ class Configuration::Loader
 
   getter new_k3s_version : String?
   getter configuration_file_path : String
+  getter skip_current_ip_validation : Bool = false
 
   private property force : Bool = false
 
-  def initialize(@configuration_file_path, @new_k3s_version, @force)
+  def initialize(@configuration_file_path, @new_k3s_version, @force, @skip_current_ip_validation = false)
     @settings = Configuration::Main.from_yaml(File.read(configuration_file_path))
 
     Configuration::Validators::ConfigurationFilePath.new(errors, configuration_file_path).validate
@@ -98,7 +99,8 @@ class Configuration::Loader
       masters_pool: masters_pool,
       instance_types: instance_types,
       all_locations: all_locations,
-      new_k3s_version: new_k3s_version
+      new_k3s_version: new_k3s_version,
+      skip_current_ip_validation: skip_current_ip_validation
     ).validate(command)
   end
 

--- a/src/configuration/models/networking_config/ssh.cr
+++ b/src/configuration/models/networking_config/ssh.cr
@@ -4,6 +4,7 @@ class Configuration::Models::NetworkingConfig::SSH
 
   getter port : Int32 = 22
   getter use_agent : Bool = false
+  getter use_private_ip : Bool = false
   getter private_key_path : String = "~/.ssh/id_rsa"
   getter public_key_path : String = "~/.ssh/id_rsa.pub"
 

--- a/src/configuration/validators/command_specific_settings.cr
+++ b/src/configuration/validators/command_specific_settings.cr
@@ -16,6 +16,7 @@ class Configuration::Validators::CommandSpecificSettings
   getter instance_types : Array(Hetzner::InstanceType)
   getter all_locations : Array(Hetzner::Location)
   getter new_k3s_version : String?
+  getter skip_current_ip_validation : Bool = false
 
   def initialize(
     @errors,
@@ -25,7 +26,8 @@ class Configuration::Validators::CommandSpecificSettings
     @masters_pool,
     @instance_types,
     @all_locations,
-    @new_k3s_version
+    @new_k3s_version,
+    @skip_current_ip_validation = false
   )
   end
 
@@ -50,7 +52,8 @@ class Configuration::Validators::CommandSpecificSettings
       hetzner_client: hetzner_client,
       masters_pool: masters_pool,
       instance_types: instance_types,
-      all_locations: all_locations
+      all_locations: all_locations,
+      skip_current_ip_validation: skip_current_ip_validation
     ).validate
   end
 

--- a/src/configuration/validators/create_settings.cr
+++ b/src/configuration/validators/create_settings.cr
@@ -21,6 +21,7 @@ class Configuration::Validators::CreateSettings
   getter masters_pool : Configuration::Models::MasterNodePool
   getter instance_types : Array(Hetzner::InstanceType)
   getter all_locations : Array(Hetzner::Location)
+  getter skip_current_ip_validation : Bool = false
 
   def initialize(
     @errors,
@@ -29,7 +30,8 @@ class Configuration::Validators::CreateSettings
     @hetzner_client,
     @masters_pool,
     @instance_types,
-    @all_locations
+    @all_locations,
+    @skip_current_ip_validation = false
   )
   end
 
@@ -40,7 +42,14 @@ class Configuration::Validators::CreateSettings
 
     Configuration::Validators::Datastore.new(errors, settings.datastore).validate
 
-    Configuration::Validators::Networking.new(errors, settings.networking, settings, hetzner_client, settings.networking.private_network).validate
+    Configuration::Validators::Networking.new(
+      errors,
+      settings.networking,
+      settings,
+      hetzner_client,
+      settings.networking.private_network,
+      skip_current_ip_validation: skip_current_ip_validation
+    ).validate
 
     Configuration::Validators::MastersPool.new(
       errors: errors,

--- a/src/configuration/validators/networking.cr
+++ b/src/configuration/validators/networking.cr
@@ -17,13 +17,18 @@ class Configuration::Validators::Networking
   getter settings : Configuration::Main
   getter hetzner_client : Hetzner::Client
   getter private_network : Configuration::Models::NetworkingConfig::PrivateNetwork
+  getter skip_current_ip_validation : Bool = false
 
-  def initialize(@errors, @networking, @settings, @hetzner_client, @private_network)
+  def initialize(@errors, @networking, @settings, @hetzner_client, @private_network, @skip_current_ip_validation = false)
   end
 
   def validate
     Configuration::Validators::NetworkingConfig::CNI.new(errors, networking.cni, private_network).validate
-    Configuration::Validators::NetworkingConfig::AllowedNetworks.new(errors, networking.allowed_networks).validate
+    Configuration::Validators::NetworkingConfig::AllowedNetworks.new(
+      errors,
+      networking.allowed_networks,
+      skip_current_ip_validation: skip_current_ip_validation
+    ).validate
     Configuration::Validators::NetworkingConfig::PrivateNetwork.new(errors, private_network, hetzner_client).validate
     Configuration::Validators::NetworkingConfig::PublicNetwork.new(errors, networking.public_network, settings).validate
     Configuration::Validators::NetworkingConfig::SSH.new(errors, networking.ssh, hetzner_client, settings.cluster_name).validate

--- a/src/configuration/validators/networking_config/allowed_networks.cr
+++ b/src/configuration/validators/networking_config/allowed_networks.cr
@@ -7,8 +7,9 @@ require "./firewall_rule"
 class Configuration::Validators::NetworkingConfig::AllowedNetworks
   getter errors : Array(String) = [] of String
   getter allowed_networks : Configuration::Models::NetworkingConfig::AllowedNetworks
+  getter skip_current_ip_validation : Bool = false
 
-  def initialize(@errors, @allowed_networks)
+  def initialize(@errors, @allowed_networks, @skip_current_ip_validation = false)
   end
 
   def validate
@@ -50,7 +51,9 @@ class Configuration::Validators::NetworkingConfig::AllowedNetworks
         errors << "#{network_type} allowed network #{cidr} is not a valid network in CIDR notation"
       end
     end
-    
+
+    return if skip_current_ip_validation
+
     validate_current_ip_must_be_included_in_at_least_one_network(errors, networks, network_type)
   end
 

--- a/src/hetzner-k3s.cr
+++ b/src/hetzner-k3s.cr
@@ -47,8 +47,20 @@ module Hetzner::K3s
         required: false,
         default: false
 
+      define_flag skip_current_ip_validation : Bool,
+        description: "Skip validation that your current IP is included in allowed SSH/API networks",
+        long: "skip-current-ip-validation",
+        required: false,
+        default: false
+
       def run
-        configuration = ::Hetzner::K3s::CLI.load_configuration(flags.configuration_file_path, nil, true, :create)
+        configuration = ::Hetzner::K3s::CLI.load_configuration(
+          flags.configuration_file_path,
+          nil,
+          true,
+          :create,
+          skip_current_ip_validation: flags.skip_current_ip_validation
+        )
         Cluster::Create.new(configuration: configuration).run
         ::Hetzner::K3s::CLI.print_sponsor_message unless flags.quiet
       end
@@ -208,9 +220,9 @@ module Hetzner::K3s
       puts help
     end
 
-    def self.load_configuration(file_path, new_k3s_version = nil, force = true, action = nil)
+    def self.load_configuration(file_path, new_k3s_version = nil, force = true, action = nil, skip_current_ip_validation = false)
       ::Hetzner::K3s::CLI.print_banner
-      configuration = Configuration::Loader.new(file_path, new_k3s_version, force)
+      configuration = Configuration::Loader.new(file_path, new_k3s_version, force, skip_current_ip_validation)
       configuration.validate(action) if action
       configuration
     end

--- a/src/hetzner/instance.cr
+++ b/src/hetzner/instance.cr
@@ -19,8 +19,10 @@ class Hetzner::Instance
     private_net.try(&.first?).try(&.ip) || public_ip_address
   end
 
-  def host_ip_address : String?
-    public_ip_address || private_ip_address
+  def host_ip_address(prefer_private_ip : Bool = false) : String?
+    private_ip = private_net.try(&.first?).try(&.ip)
+    public_ip = public_ip_address
+    prefer_private_ip ? (private_ip || public_ip) : (public_ip || private_ip)
   end
 
   def master?

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -36,7 +36,7 @@ class Hetzner::Instance::Create
   private getter ssh : Configuration::Models::NetworkingConfig::SSH
   private getter mutex : Mutex
   private getter ssh_client : Util::SSH do
-    Util::SSH.new(ssh.private_key_path, ssh.public_key_path)
+    Util::SSH.new(ssh.private_key_path, ssh.public_key_path, ssh.use_private_ip)
   end
   private property instance_existed : Bool = false
   private property powering_on_count : Int32 = 0

--- a/src/k3s.cr
+++ b/src/k3s.cr
@@ -58,7 +58,8 @@ module K3s
     begin
       ssh_client = ::Util::SSH.new(
         settings.networking.ssh.private_key_path,
-        settings.networking.ssh.public_key_path
+        settings.networking.ssh.public_key_path,
+        settings.networking.ssh.use_private_ip
       )
 
       result = ssh_client.run(
@@ -80,7 +81,8 @@ module K3s
     begin
       ssh_client = ::Util::SSH.new(
         settings.networking.ssh.private_key_path,
-        settings.networking.ssh.public_key_path
+        settings.networking.ssh.public_key_path,
+        settings.networking.ssh.use_private_ip
       )
 
       result = ssh_client.run(

--- a/src/util/ssh.cr
+++ b/src/util/ssh.cr
@@ -19,8 +19,9 @@ class Util::SSH
 
   getter private_ssh_key_path : String
   getter public_ssh_key_path : String
+  getter prefer_private_ip : Bool = false
 
-  def initialize(@private_ssh_key_path, @public_ssh_key_path)
+  def initialize(@private_ssh_key_path, @public_ssh_key_path, @prefer_private_ip = false)
   end
 
   def self.calculate_fingerprint(public_ssh_key_path)
@@ -78,7 +79,7 @@ class Util::SSH
 
   # Run a command on a remote instance via SSH
   def run(instance, port, command, use_ssh_agent, print_output = true, disable_log_prefix = false, capture_output = false)
-    host_ip_address = instance.host_ip_address
+    host_ip_address = instance.host_ip_address(prefer_private_ip)
     raise "Instance #{instance.name} has no IP address" unless host_ip_address
 
     debug = ENV.fetch("DEBUG", "false") == "true"


### PR DESCRIPTION
#### Attempted goal
1.	Set up a WG cloud instance to act as a gateway for a non-public cluster (SSH and API access).
2.	The gateway is part of the project’s internal network and therefore has access to all cluster nodes.
3.	Connections to the cluster are routed through the gateway using MASQUERADE, so all cluster nodes see the traffic as originating from the gateway, in line with firewall rules that restrict SSH and API access to the local network.

#### Issues
•	The tool’s IP validation prevents the workflow from proceeding.
•	Even when IP validation is bypassed, the tool still attempts to connect to cluster nodes using their public IP addresses instead of their private ones.

#### Solution
•	Added a skip-current-ip-validation option.
•	Added support for connecting to cluster nodes via their private IP addresses.