### PR TITLE
fix etcd s3 force path style

### DIFF
--- a/src/configuration/models/datastore_config/etcd.cr
+++ b/src/configuration/models/datastore_config/etcd.cr
@@ -101,7 +101,7 @@ class Configuration::Models::DatastoreConfig::Etcd
       args << "--etcd-s3-secret-key=#{s3_secret_key_with_env_fallback}"
 
       if s3_force_path_style
-        args << "--etcd-s3-force-path-style"
+        args << "--etcd-s3-bucket-lookup-type=path"
       end
 
       unless s3_folder.empty?


### PR DESCRIPTION
#### Issue

Setting `datastore.etcd.s3_force_path_style` to `true` triggers the creation of a non existing k3s arg `--etcd-s3-force-path-style`

`Feb 05 12:40:31 mgmt-master2 k3s[8930]: time="2026-02-05T12:40:31Z" level=fatal msg="Error: flag provided but not defined: -etcd-s3-force-path-style"`

#### Solution

Based on the [docs](https://docs.k3s.io/cli/etcd-snapshot#s3-compatible-object-store-support) – while keeping the current setting – the tool now creates `--etcd-s3-bucket-lookup-type` with a value of `path` instead (valid options are: `'auto', 'dns', 'path'`), i.e. `--etcd-s3-bucket-lookup-type=path`.

This also fixes #726 