### PR TITLE
make NodePort range configurable and add ability to disable it alltogether

### DIFF
--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -57,6 +57,8 @@ networking:
     #     port: 60000-60100
     #     destination_ips:
     #       - 203.0.113.0/24
+  # node_port_firewall_enabled: true # optional: set false to disable NodePort firewall rules (TCP/UDP)
+  # node_port_range: "30000-32767" # optional: NodePort range to open on firewalls (TCP/UDP)
   public_network:
     ipv4: true
     ipv6: true
@@ -371,4 +373,3 @@ The `create` command can be run multiple times with the same configuration witho
 eval "$(ssh-agent -s)"
 ssh-add --apple-use-keychain ~/.ssh/<private key>
 ```
-

--- a/src/configuration/models/networking.cr
+++ b/src/configuration/models/networking.cr
@@ -15,9 +15,15 @@ module Configuration
       getter public_network : ::Configuration::Models::NetworkingConfig::PublicNetwork = ::Configuration::Models::NetworkingConfig::PublicNetwork.new
       getter allowed_networks : ::Configuration::Models::NetworkingConfig::AllowedNetworks = ::Configuration::Models::NetworkingConfig::AllowedNetworks.new
       getter ssh : ::Configuration::Models::NetworkingConfig::SSH = ::Configuration::Models::NetworkingConfig::SSH.new
+      getter node_port_firewall_enabled : Bool = true
+      getter node_port_range : String = "30000-32767"
       getter cluster_cidr : String = "10.244.0.0/16"
       getter service_cidr : String = "10.43.0.0/16"
       getter cluster_dns : String = "10.43.0.10"
+
+      def node_port_range_iptables : String
+        node_port_range.includes?("-") ? node_port_range.gsub("-", ":") : node_port_range
+      end
 
       def initialize
       end

--- a/src/configuration/validators/networking.cr
+++ b/src/configuration/validators/networking.cr
@@ -7,6 +7,7 @@ require "../models/networking_config/public_network"
 require "../models/networking_config/ssh"
 require "./networking_config/cni"
 require "./networking_config/allowed_networks"
+require "./networking_config/node_port_range"
 require "./networking_config/private_network"
 require "./networking_config/public_network"
 require "./networking_config/ssh"
@@ -24,6 +25,7 @@ class Configuration::Validators::Networking
   def validate
     Configuration::Validators::NetworkingConfig::CNI.new(errors, networking.cni, private_network).validate
     Configuration::Validators::NetworkingConfig::AllowedNetworks.new(errors, networking.allowed_networks).validate
+    Configuration::Validators::NetworkingConfig::NodePortRange.new(errors, networking.node_port_range).validate
     Configuration::Validators::NetworkingConfig::PrivateNetwork.new(errors, private_network, hetzner_client).validate
     Configuration::Validators::NetworkingConfig::PublicNetwork.new(errors, networking.public_network, settings).validate
     Configuration::Validators::NetworkingConfig::SSH.new(errors, networking.ssh, hetzner_client, settings.cluster_name).validate

--- a/src/configuration/validators/networking_config/node_port_range.cr
+++ b/src/configuration/validators/networking_config/node_port_range.cr
@@ -1,0 +1,37 @@
+class Configuration::Validators::NetworkingConfig::NodePortRange
+  getter errors : Array(String)
+  getter node_port_range : String
+
+  def initialize(@errors, @node_port_range)
+  end
+
+  def validate
+    unless node_port_range =~ /^\d+(-\d+)?$/
+      errors << "networking.node_port_range must be a single port (\"30000\") or range (\"30000-32767\")"
+      return
+    end
+
+    parts = node_port_range.split("-")
+    if parts.size == 1
+      validate_port(parts[0].to_i)
+      return
+    end
+
+    start_port = parts[0].to_i
+    end_port = parts[1].to_i
+
+    if start_port > end_port
+      errors << "networking.node_port_range must have start <= end (given #{node_port_range})"
+      return
+    end
+
+    validate_port(start_port)
+    validate_port(end_port)
+  end
+
+  private def validate_port(port : Int32) : Nil
+    return if port >= 1 && port <= 65_535
+
+    errors << "networking.node_port_range values must be between 1 and 65535 (given #{node_port_range})"
+  end
+end

--- a/src/hetzner/instance/cloud_init_generator.cr
+++ b/src/hetzner/instance/cloud_init_generator.cr
@@ -67,6 +67,8 @@ class Hetzner::Instance::CloudInitGenerator
       ssh_port:                     @settings.networking.ssh.port,
       cluster_cidr:                 @settings.networking.cluster_cidr,
       service_cidr:                 @settings.networking.service_cidr,
+      node_port_range_iptables:     @settings.networking.node_port_range_iptables,
+      node_port_firewall_enabled:   @settings.networking.node_port_firewall_enabled,
     })
     format_file_content(script)
   end

--- a/src/kubernetes/local_firewall/setup.cr
+++ b/src/kubernetes/local_firewall/setup.cr
@@ -125,6 +125,8 @@ class Kubernetes::LocalFirewall::Setup
       ssh_port:                     settings.networking.ssh.port,
       cluster_cidr:                 settings.networking.cluster_cidr,
       service_cidr:                 settings.networking.service_cidr,
+      node_port_range_iptables:     settings.networking.node_port_range_iptables,
+      node_port_firewall_enabled:   settings.networking.node_port_firewall_enabled,
     })
   end
 


### PR DESCRIPTION
I think @roy-hardin had a valid point in #474. Even though you wrote _"Ports 30000-32767 are required for NodePort services, so they only pose a risk if you explicitly decide to expose a service to the Internet on a NodePort. Otherwise those ports are not in use so they don't pose any risk IMO."_ I think that opening the full NodePort range to source:any leaves an unnecessary attack surface.

Because: Even if we don’t plan to use NodePorts directly, sometimes they can appear implicitly (chart defaults, upgrades, misclicks) and would become publicly reachable immediately. Having an option to disable them or make them configurable keeps the flexibility while avoiding accidental exposure.

Small off-topic question: Did I get it right and if so: is it intentional to not use `custom_firewall_rules` for the custom firewall when using `use_local_firewall`: `true`?