### PR TITLE
fix(install scripts): add #!/bin/bash shebang so PIPESTATUS works under dash

### DIFF
--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 touch /etc/initialized
 
 HOSTNAME=$(hostname -f)

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 touch /etc/initialized
 
 HOSTNAME=$(hostname -f)


### PR DESCRIPTION
## Problem

`templates/worker_install_script.sh` and `templates/master_install_script.sh` use the bash-only `\${PIPESTATUS[0]}` to check whether the k3s install pipe succeeded:

```bash
curl -sfL https://get.k3s.io | … | tee -a /var/log/hetzner-k3s.log

if [ \${PIPESTATUS[0]} -ne 0 ]; then
  echo "ERROR: k3s installation failed" …
  exit 1
fi
```

Neither file declares a shebang. cloud-init runs each `runcmd:` entry via `execve()`; on Ubuntu the kernel falls back to `/bin/sh` which is **dash** — and dash does not implement `\${PIPESTATUS[0]}`.

Reproduce on any fresh 2.4.9 worker (Ubuntu 24.04):

```
$ ssh root@<worker> 'sh -c "true | true; echo \${PIPESTATUS[0]}"'
sh: 1: Bad substitution
```

## Symptoms downstream

Because cloud-init's runcmd has `set -e` internally, **the `Bad substitution` aborts the entire runcmd**. Visible effects on affected nodes:

| What | Reality on the node |
|---|---|
| `cloud-init status` | `error` |
| k3s-agent | installed (the curl pipe completed before the PIPESTATUS check) ✓ |
| `additional_packages: [nfs-common]` | silently skipped — `dpkg -l nfs-common` shows `un` |
| `additional_post_k3s_commands` | silently skipped — never reached |
| `/var/log/cloud-init-output.log` | `/etc/init-0.sh: 104: Bad substitution` followed by no further runcmd output |

Real-world impact: every NFS-backed PVC pod scheduled to a fresh Cluster-Autoscaler-spawned worker hangs forever in `ContainerCreating`:

```
MountVolume.SetUp failed for volume "websites-data-nfs":
mount failed: exit status 32 …
mount: bad option; for several filesystems (e.g. nfs, cifs) you might
need a /sbin/mount.<type> helper program.
```

— because nfs-common was never installed.

## Fix

```diff
+ #!/bin/bash
  touch /etc/initialized
```

at the top of both `templates/worker_install_script.sh` and `templates/master_install_script.sh`. The bodies already use bash idioms, so the declaration just makes it honest.

* No behavior change for anyone whose `/bin/sh` is bash (e.g. some RHEL-family distros).
* Unblocks the dash-based distros that the project already supports (Debian / Ubuntu / Mint).
* 2-line diff, no test surface.

## Verification

1. Patched both templates locally.
2. `hetzner-k3s create --config cluster.yaml` (idempotent re-apply — refreshes the Cluster-Autoscaler ConfigMap's embedded cloud-init).
3. Forced a CA scale-up by deploying a workload requiring an empty pool.
4. SSH'd the new worker (uptime ~30 s):
   * `cloud-init status` → `done`
   * `command -v mount.nfs` → `/usr/sbin/mount.nfs` ✓
   * `additional_post_k3s_commands` ran (visible in `/var/log/cloud-init-output.log`).

Filed alongside without an upstream issue since it's a tiny, self-contained one-line-each repro+fix; happy to open one if preferred.