### PR TITLE
feat: allow using existing SSH key instead of creating a new one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,4 @@ hetzner-k3s-bin
 .kilocode/mcp.json
 .kilocodemodes
 marketing/
-AGENTS.md
 CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# hetzner-k3s
+
+Crystal CLI tool that provisions production-ready k3s clusters on Hetzner Cloud.
+
+## Build and Run
+
+All build/test commands run inside the Docker dev container, not on the host:
+
+```bash
+docker compose run --rm hetzner-k3s <command>
+```
+
+Key commands:
+- `shards install` — install dependencies
+- `crystal build --no-codegen src/hetzner-k3s.cr` — syntax/type check without producing a binary
+- `crystal build src/hetzner-k3s.cr` — build debug binary
+- `crystal build src/hetzner-k3s.cr --release` — build release binary
+- `crystal tool format` — format check
+- `crystal build src/hetzner-k3s.cr --release --static` — static build (Linux only)
+
+## Architecture
+
+Entry point: `src/hetzner-k3s.cr` — Admiral-based CLI with subcommands: `create`, `delete`, `upgrade`, `run`
+
+Module layout under `src/`:
+- `hetzner/` — Hetzner Cloud API client (firewall, instance, load_balancer, network, ssh_key)
+- `configuration/` — YAML config models and validators
+- `kubernetes/` — k3s/k8s setup (control_plane, worker, scripts, software, resources)
+- `cluster/` — high-level cluster operations (create, delete, upgrade, run)
+- `k3s.cr` — k3s release fetching and token management
+- `util/` — shell helpers
+
+## Testing
+
+No unit test suite. Only e2e tests in `e2e-tests/` that create/delete real Hetzner clusters (requires API token). These are slow and sequential — not suitable for quick verification.
+
+Use `crystal build --no-codegen` for fast type/syntax checking instead.
+
+## Workflow
+
+- Never commit or push without explicit user permission — always ask first
+- Make changes → show what was changed → stop and ask before committing/pushing
+
+## Code Style
+
+- Double quotes for all string literals (`"string"`, not `'string'`)
+- 2-space indent, UTF-8, LF line endings (`.editorconfig`)
+- Crystal formatter: `crystal tool format`
+
+## Gotchas
+
+- `shard.yml` lists Crystal 1.5.0 but CI builds with 1.14.1 — the `shard.yml` value is stale; use the Docker container's Crystal version as the effective target
+- The dev container (Alpine-based) includes kubectl, helm, k9s, stern — useful for debugging running clusters
+- Linux release builds are statically linked (`--static`); macOS builds are not
+- Dependencies are installed with `shards install --without-development` in CI

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ brew install vitobotta/tap/hetzner_k3s
 
 **Linux binary (amd64):**
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.9/hetzner-k3s-linux-amd64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.5.0/hetzner-k3s-linux-amd64
 chmod +x hetzner-k3s-linux-amd64
 sudo mv hetzner-k3s-linux-amd64 /usr/local/bin/hetzner-k3s
 ```

--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -22,6 +22,7 @@ networking:
     use_private_ip: false # set to true to connect to nodes via their private IPs
     public_key_path: "~/.ssh/id_ed25519.pub"
     private_key_path: "~/.ssh/id_ed25519"
+    # existing_ssh_key_name: "my-existing-key" # optional: use an existing SSH key in Hetzner instead of creating a new one
   allowed_networks:
     ssh:
       - 0.0.0.0/0
@@ -369,7 +370,7 @@ The `create` command can be run multiple times with the same configuration witho
 - The `networking`.`allowed_networks`.`api` setting specifies which networks can access the Kubernetes API. This works with both single-master and multi-master clusters, but only when `create_load_balancer_for_the_kubernetes_api` is disabled. If the API load balancer is enabled, Hetzner's firewalls do not yet support load balancers, so the API would be exposed to the public internet regardless of the allowed networks configuration.
 - If you enable autoscaling for a nodepool, avoid changing this setting later, as it can cause issues with the autoscaler.
 - Autoscaling is only supported with Ubuntu or other default images, not snapshots.
-- If you already have SSH keys in your Hetzner project, it's best to use a different key for your cluster—unless there's already a key with the same name and fingerprint as the one in your config file.  Hetzner doesn't allow two keys with the same fingerprint in one project. So if you've already added the key from your config but under a different name, Hetzner won't let you add it again. In that case, hetzner-k3s will skip creating the key and won't inject any SSH key into the cluster nodes.  Without an SSH key, Hetzner sets up the nodes with password login instead. That means you'll get an email for each node with its root password. Managing several nodes this way can get tricky. To avoid this, just use a new keypair for your cluster—unless the project already has a key that matches both the name and fingerprint in your config.
+- If you already have SSH keys in your Hetzner project, it's best to use a different key for your cluster—unless there's already a key with the same name and fingerprint as the one in your config file.  Hetzner doesn't allow two keys with the same fingerprint in one project. So if you've already added the key from your config but under a different name, Hetzner won't let you add it again. In that case, hetzner-k3s will skip creating the key and won't inject any SSH key into the cluster nodes.  Without an SSH key, Hetzner sets up the nodes with password login instead. That means you'll get an email for each node with its root password. Managing several nodes this way can get tricky. To avoid this, you can either use a new keypair for your cluster, or set `existing_ssh_key_name` in the SSH config to reference the existing key by name. When using `existing_ssh_key_name`, hetzner-k3s will use the specified key instead of creating a new one, and it won't delete the key when you delete the cluster.
 - SSH keys with passphrases can only be used if you set `networking`.`ssh`.`use_ssh_agent` to `true` and use an SSH agent to access your key. For example, on macOS, you can start an agent like this:
 
 ```bash

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -40,14 +40,14 @@ If you prefer not to use Homebrew, install the required dependencies first:
 
 **Apple Silicon:**
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.9/hetzner-k3s-macos-arm64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.5.0/hetzner-k3s-macos-arm64
 chmod +x hetzner-k3s-macos-arm64
 sudo mv hetzner-k3s-macos-arm64 /usr/local/bin/hetzner-k3s
 ```
 
 **Intel:**
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.9/hetzner-k3s-macos-amd64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.5.0/hetzner-k3s-macos-amd64
 chmod +x hetzner-k3s-macos-amd64
 sudo mv hetzner-k3s-macos-amd64 /usr/local/bin/hetzner-k3s
 ```
@@ -67,7 +67,7 @@ brew install vitobotta/tap/hetzner_k3s
 ### amd64 (x86_64)
 
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.9/hetzner-k3s-linux-amd64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.5.0/hetzner-k3s-linux-amd64
 chmod +x hetzner-k3s-linux-amd64
 sudo mv hetzner-k3s-linux-amd64 /usr/local/bin/hetzner-k3s
 ```
@@ -75,7 +75,7 @@ sudo mv hetzner-k3s-linux-amd64 /usr/local/bin/hetzner-k3s
 ### arm64 (ARM)
 
 ```bash
-wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.4.9/hetzner-k3s-linux-arm64
+wget https://github.com/vitobotta/hetzner-k3s/releases/download/v2.5.0/hetzner-k3s-linux-arm64
 chmod +x hetzner-k3s-linux-arm64
 sudo mv hetzner-k3s-linux-arm64 /usr/local/bin/hetzner-k3s
 ```

--- a/src/cluster/delete.cr
+++ b/src/cluster/delete.cr
@@ -118,8 +118,9 @@ class Cluster::Delete
   private def delete_ssh_key
     Hetzner::SSHKey::Delete.new(
       hetzner_client: hetzner_client,
-      ssh_key_name: settings.cluster_name,
-      public_ssh_key_path: settings.networking.ssh.public_key_path
+      ssh_key_name: settings.networking.ssh.ssh_key_name(settings.cluster_name),
+      public_ssh_key_path: settings.networking.ssh.public_key_path,
+      using_existing_ssh_key: settings.networking.ssh.using_existing_ssh_key?
     ).run
   end
 

--- a/src/configuration/models/networking_config/ssh.cr
+++ b/src/configuration/models/networking_config/ssh.cr
@@ -7,6 +7,7 @@ class Configuration::Models::NetworkingConfig::SSH
   getter use_private_ip : Bool = false
   getter private_key_path : String = "~/.ssh/id_rsa"
   getter public_key_path : String = "~/.ssh/id_rsa.pub"
+  getter existing_ssh_key_name : String = ""
 
   def initialize
   end
@@ -17,6 +18,14 @@ class Configuration::Models::NetworkingConfig::SSH
 
   def public_key_path
     absolute_path(@public_key_path)
+  end
+
+  def ssh_key_name(cluster_name : String) : String
+    @existing_ssh_key_name.empty? ? cluster_name : @existing_ssh_key_name
+  end
+
+  def using_existing_ssh_key? : Bool
+    !@existing_ssh_key_name.empty?
   end
 
   private def absolute_path(path)

--- a/src/configuration/validators/autoscaler_ssh_key.cr
+++ b/src/configuration/validators/autoscaler_ssh_key.cr
@@ -13,17 +13,19 @@ class Configuration::Validators::AutoscalerSSHKey
   def validate
     return unless autoscaling_in_use?
 
+    ssh_key_name = settings.networking.ssh.ssh_key_name(settings.cluster_name)
+
     begin
-      existing_ssh_key = Hetzner::SSHKey::Find.new(hetzner_client, settings.cluster_name, settings.networking.ssh.public_key_path).run
+      existing_ssh_key = Hetzner::SSHKey::Find.new(hetzner_client, ssh_key_name, settings.networking.ssh.public_key_path).run
     rescue ex
       errors << "Unable to verify SSH key for autoscaler: #{ex.message}"
       return
     end
 
     return unless existing_ssh_key
-    return if existing_ssh_key.name == settings.cluster_name
+    return if existing_ssh_key.name == ssh_key_name
 
-    errors << "Cluster autoscaler requires an SSH key named '#{settings.cluster_name}' in Hetzner. A key with the same fingerprint exists as '#{existing_ssh_key.name}', so hetzner-k3s will not create '#{settings.cluster_name}'. Autoscaled nodes will be created without SSH keys. Rename or delete the existing key, or change cluster_name."
+    errors << "Cluster autoscaler requires an SSH key named '#{ssh_key_name}' in Hetzner. A key with the same fingerprint exists as '#{existing_ssh_key.name}', so hetzner-k3s will not create '#{ssh_key_name}'. Autoscaled nodes will be created without SSH keys. Rename or delete the existing key, or use the existing_ssh_key_name setting to reference it."
   end
 
   private def autoscaling_in_use?

--- a/src/configuration/validators/networking_config/ssh.cr
+++ b/src/configuration/validators/networking_config/ssh.cr
@@ -15,7 +15,12 @@ class Configuration::Validators::NetworkingConfig::SSH
   def validate
     validate_path(errors, ssh.private_key_path, "private")
     validate_path(errors, ssh.public_key_path, "public")
-    validate_ssh_key_fingerprint(errors, hetzner_client, cluster_name)
+
+    if ssh.using_existing_ssh_key?
+      validate_existing_ssh_key(errors, hetzner_client)
+    else
+      validate_ssh_key_fingerprint(errors, hetzner_client, cluster_name)
+    end
   end
 
   private def validate_path(errors, path, key_type)
@@ -36,13 +41,41 @@ class Configuration::Validators::NetworkingConfig::SSH
     end
   end
 
+  private def validate_existing_ssh_key(errors, hetzner_client)
+    unless File.exists?(ssh.public_key_path)
+      errors << "public_key_path is required to validate the fingerprint of existing_ssh_key_name '#{ssh.existing_ssh_key_name}'"
+      return
+    end
+
+    begin
+      existing_ssh_key = Hetzner::SSHKey::Find.new(hetzner_client.not_nil!, ssh.existing_ssh_key_name, ssh.public_key_path).run
+    rescue e
+      errors << "Unable to verify existing SSH key '#{ssh.existing_ssh_key_name}': #{e.message}"
+      return
+    end
+
+    unless existing_ssh_key
+      errors << "The SSH key '#{ssh.existing_ssh_key_name}' specified in existing_ssh_key_name does not exist in Hetzner"
+      return
+    end
+
+    unless existing_ssh_key.name == ssh.existing_ssh_key_name
+      errors << "SSH key mismatch: the key '#{ssh.existing_ssh_key_name}' was not found by name in Hetzner. A key with the same fingerprint exists as '#{existing_ssh_key.name}', but existing_ssh_key_name must match the key name exactly."
+      return
+    end
+
+    config_fingerprint = Util::SSH.calculate_fingerprint(ssh.public_key_path)
+
+    if existing_ssh_key.fingerprint != config_fingerprint
+      errors << "SSH key fingerprint mismatch: the existing key '#{ssh.existing_ssh_key_name}' in Hetzner has a different fingerprint than the local public key at '#{ssh.public_key_path}'. Please ensure the public_key_path points to the corresponding public key."
+    end
+  end
+
   private def find_existing_ssh_key(hetzner_client, cluster_name)
     return nil unless hetzner_client && cluster_name
     ssh_key_finder = Hetzner::SSHKey::Find.new(hetzner_client, cluster_name, ssh.public_key_path)
     ssh_key_finder.run
   rescue e
-    # If we can't fetch existing SSH keys, we'll skip validation
-    # This allows the create command to proceed and handle any API errors
     nil
   end
 end

--- a/src/hetzner-k3s.cr
+++ b/src/hetzner-k3s.cr
@@ -10,7 +10,7 @@ require "./cluster/run"
 
 module Hetzner::K3s
   class CLI < Admiral::Command
-    VERSION = "2.4.9"
+    VERSION = "2.5.0"
 
     def self.print_banner
       puts "╭─────────────────────────────────────────╮".colorize(:green)

--- a/src/hetzner/ssh_key/create.cr
+++ b/src/hetzner/ssh_key/create.cr
@@ -12,7 +12,7 @@ class Hetzner::SSHKey::Create
   getter ssh_key_finder : Hetzner::SSHKey::Find
 
   def initialize(@hetzner_client, @settings)
-    @ssh_key_name = settings.cluster_name
+    @ssh_key_name = settings.networking.ssh.ssh_key_name(settings.cluster_name)
     @public_ssh_key_path = settings.networking.ssh.public_key_path
     @ssh_key_finder = Hetzner::SSHKey::Find.new(hetzner_client, ssh_key_name, public_ssh_key_path)
   end
@@ -21,6 +21,11 @@ class Hetzner::SSHKey::Create
     ssh_key = ssh_key_finder.run
 
     return ssh_key if ssh_key
+
+    if settings.networking.ssh.using_existing_ssh_key?
+      STDERR.puts "[#{default_log_prefix}] Existing SSH key '#{ssh_key_name}' not found in Hetzner"
+      exit 1
+    end
 
     log_line "Creating SSH key..."
     create_ssh_key

--- a/src/hetzner/ssh_key/delete.cr
+++ b/src/hetzner/ssh_key/delete.cr
@@ -8,18 +8,26 @@ class Hetzner::SSHKey::Delete
   getter hetzner_client : Hetzner::Client
   getter ssh_key_name : String
   getter ssh_key_finder : Hetzner::SSHKey::Find
+  getter using_existing_ssh_key : Bool
 
-  def initialize(@hetzner_client, @ssh_key_name, public_ssh_key_path)
+  def initialize(@hetzner_client, @ssh_key_name, public_ssh_key_path, @using_existing_ssh_key = false)
     @ssh_key_finder = Hetzner::SSHKey::Find.new(hetzner_client, ssh_key_name, public_ssh_key_path)
   end
 
   def run
+    return handle_existing_ssh_key_skip if using_existing_ssh_key
+
     ssh_key = ssh_key_finder.run
 
     return handle_no_ssh_key unless ssh_key
     return handle_existing_ssh_key(ssh_key) if ssh_key.name == ssh_key_name
 
     log_line "An SSH key with the expected fingerprint existed before creating the cluster, so I won't delete it"
+    ssh_key_name
+  end
+
+  private def handle_existing_ssh_key_skip
+    log_line "Using existing SSH key '#{ssh_key_name}', skipping delete"
     ssh_key_name
   end
 

--- a/src/hetzner/ssh_key/find.cr
+++ b/src/hetzner/ssh_key/find.cr
@@ -6,17 +6,21 @@ require "../../util/ssh"
 class Hetzner::SSHKey::Find
   private getter hetzner_client : Hetzner::Client
   private getter ssh_key_name : String
-  private getter public_ssh_key_path : String
+  private getter public_ssh_key_path : String?
 
   def initialize(@hetzner_client, @ssh_key_name, @public_ssh_key_path)
   end
 
   def run
     ssh_keys = fetch_ssh_keys
-    fingerprint = Util::SSH.calculate_fingerprint(public_ssh_key_path)
 
-    ssh_keys.find { |ssh_key| ssh_key.fingerprint == fingerprint } ||
+    if public_ssh_key_path && File.exists?(public_ssh_key_path.not_nil!)
+      fingerprint = Util::SSH.calculate_fingerprint(public_ssh_key_path.not_nil!)
+      ssh_keys.find { |ssh_key| ssh_key.fingerprint == fingerprint } ||
+        ssh_keys.find { |ssh_key| ssh_key.name == ssh_key_name }
+    else
       ssh_keys.find { |ssh_key| ssh_key.name == ssh_key_name }
+    end
   end
 
   private def fetch_ssh_keys

--- a/src/kubernetes/software/cluster_autoscaler.cr
+++ b/src/kubernetes/software/cluster_autoscaler.cr
@@ -268,7 +268,7 @@ class Kubernetes::Software::ClusterAutoscaler
 
     set_env_variable(env_vars, HCLOUD_CLUSTER_CONFIG_FILE_VAR, "#{CLUSTER_CONFIG_MOUNT_PATH}/#{CLUSTER_CONFIG_FILE_NAME}")
     set_env_variable(env_vars, HCLOUD_FIREWALL_VAR, settings.cluster_name)
-    set_env_variable(env_vars, HCLOUD_SSH_KEY_VAR, settings.cluster_name)
+    set_env_variable(env_vars, HCLOUD_SSH_KEY_VAR, settings.networking.ssh.ssh_key_name(settings.cluster_name))
     set_env_variable(env_vars, HCLOUD_NETWORK_VAR, resolve_network_name)
     set_env_variable(env_vars, HCLOUD_PUBLIC_IPV4_VAR, settings.networking.public_network.ipv4.to_s)
     set_env_variable(env_vars, HCLOUD_PUBLIC_IPV6_VAR, settings.networking.public_network.ipv6.to_s)


### PR DESCRIPTION
## Summary

- Adds `existing_ssh_key_name` config option under `networking.ssh` to specify the name of an existing SSH key in the Hetzner project instead of creating a new one
- When set, validates that the key exists in Hetzner and that its fingerprint matches the local `public_key_path`
- Skips SSH key creation during `create` and skips SSH key deletion during `delete`
- The cluster autoscaler (`HCLOUD_SSH_KEY` env var) and autoscaler validator use the resolved SSH key name
- Follows the same pattern as `existing_network_name` for private networks
- Bumps version to 2.5.0

## Changes

| File | Change |
|------|--------|
| `src/configuration/models/networking_config/ssh.cr` | Add `existing_ssh_key_name` field, `ssh_key_name(cluster_name)` helper, `using_existing_ssh_key?` predicate |
| `src/configuration/validators/networking_config/ssh.cr` | Validate existing key exists in Hetzner + fingerprint matches local key |
| `src/hetzner/ssh_key/find.cr` | Make `public_ssh_key_path` nullable; fall back to name-only search when path unavailable |
| `src/hetzner/ssh_key/create.cr` | Use resolved SSH key name; abort gracefully if existing key not found |
| `src/hetzner/ssh_key/delete.cr` | Skip deletion when using an existing key |
| `src/cluster/delete.cr` | Pass resolved SSH key name and `using_existing_ssh_key` flag |
| `src/kubernetes/software/cluster_autoscaler.cr` | Use resolved SSH key name for `HCLOUD_SSH_KEY` |
| `src/configuration/validators/autoscaler_ssh_key.cr` | Use resolved SSH key name; updated error message |
| `src/hetzner-k3s.cr` | Bump version to 2.5.0 |
| `README.md`, `docs/Installation.md` | Update download links to v2.5.0 |
| `docs/Creating_a_cluster.md` | Document `existing_ssh_key_name` option |

## Usage

```yaml
networking:
  ssh:
    existing_ssh_key_name: "my-existing-key"  # optional
    public_key_path: "~/.ssh/id_ed25519.pub"   # still required for fingerprint validation
    private_key_path: "~/.ssh/id_ed25519"      # still required for SSH access
```

When `existing_ssh_key_name` is empty (default), all behaviour is unchanged.