### PR TITLE
Add configurable gVisor (runsc) container runtime support

### DIFF
--- a/src/configuration/models/addons.cr
+++ b/src/configuration/models/addons.cr
@@ -3,6 +3,7 @@ require "./addons_config/csi_driver"
 require "./addons_config/cloud_controller_manager"
 require "./addons_config/system_upgrade_controller"
 require "./addons_config/embedded_registry_mirror"
+require "./addons_config/gvisor"
 
 module Configuration
   module Models
@@ -37,6 +38,7 @@ module Configuration
       getter cloud_controller_manager : Configuration::Models::AddonsConfig::CloudControllerManager = Configuration::Models::AddonsConfig::CloudControllerManager.new
       getter system_upgrade_controller : Configuration::Models::AddonsConfig::SystemUpgradeController = Configuration::Models::AddonsConfig::SystemUpgradeController.new
       getter embedded_registry_mirror : Configuration::Models::AddonsConfig::EmbeddedRegistryMirror = Configuration::Models::AddonsConfig::EmbeddedRegistryMirror.new
+      getter gvisor : Configuration::Models::AddonsConfig::GVisor = Configuration::Models::AddonsConfig::GVisor.new
 
       def initialize
       end

--- a/src/configuration/models/addons_config/gvisor.cr
+++ b/src/configuration/models/addons_config/gvisor.cr
@@ -1,0 +1,20 @@
+module Configuration
+  module Models
+    module AddonsConfig
+      class GVisor
+        include YAML::Serializable
+        include YAML::Serializable::Unmapped
+
+        # Whether to enable gVisor (runsc) as an additional container runtime
+        property enabled : Bool = false
+
+        def initialize(@enabled : Bool = false)
+        end
+
+        def enabled?
+          enabled
+        end
+      end
+    end
+  end
+end

--- a/src/kubernetes/script/master_generator.cr
+++ b/src/kubernetes/script/master_generator.cr
@@ -53,11 +53,12 @@ class Kubernetes::Script::MasterGenerator
       embedded_registry_mirror_enabled: @settings.addons.embedded_registry_mirror.enabled.to_s,
       private_registry_config:          @settings.addons.embedded_registry_mirror.private_registry_config,
       local_path_storage_class_enabled: @settings.addons.local_path_storage_class.enabled.to_s,
-      traefik_enabled:        @settings.addons.traefik.enabled.to_s,
-      servicelb_enabled:      @settings.addons.servicelb.enabled.to_s,
-      metrics_server_enabled: @settings.addons.metrics_server.enabled.to_s,
-      labels_and_taints:      labels_and_taints,
-      additional_post_k3s_commands: post_k3s_commands,
+      traefik_enabled:                  @settings.addons.traefik.enabled.to_s,
+      servicelb_enabled:                @settings.addons.servicelb.enabled.to_s,
+      metrics_server_enabled:           @settings.addons.metrics_server.enabled.to_s,
+      labels_and_taints:                labels_and_taints,
+      gvisor_enabled:                   @settings.addons.gvisor.enabled?.to_s,
+      additional_post_k3s_commands:     post_k3s_commands,
     })
   end
 

--- a/src/kubernetes/script/worker_generator.cr
+++ b/src/kubernetes/script/worker_generator.cr
@@ -21,17 +21,18 @@ class Kubernetes::Script::WorkerGenerator
     post_k3s_commands = format_post_k3s_commands(pool.additional_post_k3s_commands || @settings.additional_post_k3s_commands)
 
     Crinja.render(WORKER_INSTALL_SCRIPT, {
-      cluster_name:            @settings.cluster_name,
-      k3s_token:               generate_k3s_token(masters, first_master),
-      k3s_version:             @settings.k3s_version,
-      api_server_ip_address:   api_server_ip_address(first_master),
-      private_network_enabled: @settings.networking.private_network.enabled.to_s,
-      private_network_subnet:  @settings.networking.private_network.enabled ? @settings.networking.private_network.subnet : "",
-      cluster_cidr:            @settings.networking.cluster_cidr,
-      service_cidr:               @settings.networking.service_cidr,
-      extra_args:                 kubelet_args_list,
-      labels_and_taints:          labels_and_taints,
-      private_registry_config:    @settings.addons.embedded_registry_mirror.private_registry_config,
+      cluster_name:                 @settings.cluster_name,
+      k3s_token:                    generate_k3s_token(masters, first_master),
+      k3s_version:                  @settings.k3s_version,
+      api_server_ip_address:        api_server_ip_address(first_master),
+      private_network_enabled:      @settings.networking.private_network.enabled.to_s,
+      private_network_subnet:       @settings.networking.private_network.enabled ? @settings.networking.private_network.subnet : "",
+      cluster_cidr:                 @settings.networking.cluster_cidr,
+      service_cidr:                 @settings.networking.service_cidr,
+      extra_args:                   kubelet_args_list,
+      labels_and_taints:            labels_and_taints,
+      gvisor_enabled:               @settings.addons.gvisor.enabled?.to_s,
+      private_registry_config:      @settings.addons.embedded_registry_mirror.private_registry_config,
       additional_post_k3s_commands: post_k3s_commands,
     })
   end

--- a/src/kubernetes/software/gvisor.cr
+++ b/src/kubernetes/software/gvisor.cr
@@ -1,0 +1,38 @@
+require "../../configuration/loader"
+require "../../configuration/main"
+require "../../util"
+require "../util"
+
+class Kubernetes::Software::GVisor
+  include Util
+  include Kubernetes::Util
+
+  private getter configuration : Configuration::Loader
+  private getter settings : Configuration::Main { configuration.settings }
+
+  def initialize(@configuration : Configuration::Loader, @settings : Configuration::Main)
+  end
+
+  def install : Nil
+    log_line "Creating gVisor RuntimeClass...", log_prefix: default_log_prefix
+
+    manifest = build_runtime_class_manifest
+    apply_manifest_from_yaml(manifest, "Failed to create gVisor RuntimeClass")
+
+    log_line "...gVisor RuntimeClass created", log_prefix: default_log_prefix
+  end
+
+  private def build_runtime_class_manifest : String
+    <<-YAML
+    apiVersion: node.k8s.io/v1
+    kind: RuntimeClass
+    metadata:
+      name: gvisor
+    handler: runsc
+    YAML
+  end
+
+  private def default_log_prefix : String
+    "gVisor"
+  end
+end

--- a/src/kubernetes/software/installer.cr
+++ b/src/kubernetes/software/installer.cr
@@ -9,6 +9,7 @@ require "./hetzner/cloud_controller_manager"
 require "./hetzner/csi_driver"
 require "./system_upgrade_controller"
 require "./cluster_autoscaler"
+require "./gvisor"
 
 class Kubernetes::Software::Installer
   def initialize(@configuration : Configuration::Loader, @settings : Configuration::Main)
@@ -20,6 +21,7 @@ class Kubernetes::Software::Installer
     install_hetzner_cloud_controller_manager_if_enabled
     install_hetzner_csi_driver_if_enabled
     install_system_upgrade_controller_if_enabled
+    install_gvisor_if_enabled
     install_cluster_autoscaler_if_enabled(first_master, masters, ssh, autoscaling_worker_node_pools)
   end
 
@@ -48,5 +50,8 @@ class Kubernetes::Software::Installer
       Kubernetes::Software::ClusterAutoscaler.new(@configuration, @settings, masters, first_master, ssh, autoscaling_worker_node_pools).install
     end
   end
-end
 
+  private def install_gvisor_if_enabled
+    Kubernetes::Software::GVisor.new(@configuration, @settings).install if @settings.addons.gvisor.enabled?
+  end
+end

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -117,7 +117,7 @@ apt-get update && apt-get install -y runsc
 cat >/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl <<\GVCONF
 {{ "{{ template \"base\" . }}" }}
 
-[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
 GVCONF
 

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -101,6 +101,27 @@ fi
 
 # Create k3s directories
 mkdir -p /etc/rancher/k3s
+mkdir -p /var/lib/rancher/k3s/agent/etc/containerd
+
+# Configure gVisor (runsc) if enabled
+{% if gvisor_enabled == "true" %}
+echo "Configuring containerd for gVisor..." 2>&1 | tee -a /var/log/hetzner-k3s.log
+
+# Install gVisor (runsc)
+apt-get update && apt-get install -y apt-transport-https ca-certificates curl gnupg
+curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" | tee /etc/apt/sources.list.d/gvisor.list > /dev/null
+apt-get update && apt-get install -y runsc
+
+# Create containerd config template for gVisor
+cat >/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl <<\GVCONF
+{{ "{{ template \"base\" . }}" }}
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+GVCONF
+
+echo "gVisor containerd configuration created" 2>&1 | tee -a /var/log/hetzner-k3s.log{% endif %}
 
 # Create registries.yaml
 cat >/etc/rancher/k3s/registries.yaml <<\EOF

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -60,6 +60,27 @@ fi
 
 # Create k3s directories
 mkdir -p /etc/rancher/k3s
+mkdir -p /var/lib/rancher/k3s/agent/etc/containerd
+
+# Configure gVisor (runsc) if enabled
+{% if gvisor_enabled == "true" %}
+echo "Configuring containerd for gVisor..." 2>&1 | tee -a /var/log/hetzner-k3s.log
+
+# Install gVisor (runsc)
+apt-get update && apt-get install -y apt-transport-https ca-certificates curl gnupg
+curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" | tee /etc/apt/sources.list.d/gvisor.list > /dev/null
+apt-get update && apt-get install -y runsc
+
+# Create containerd config template for gVisor
+cat >/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl <<\GVCONF
+{{ "{{ template \"base\" . }}" }}
+
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+GVCONF
+
+echo "gVisor containerd configuration created" 2>&1 | tee -a /var/log/hetzner-k3s.log{% endif %}
 
 # Create registries.yaml
 cat >/etc/rancher/k3s/registries.yaml <<\EOF

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -76,7 +76,7 @@ apt-get update && apt-get install -y runsc
 cat >/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl <<\GVCONF
 {{ "{{ template \"base\" . }}" }}
 
-[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
 GVCONF
 


### PR DESCRIPTION
Closes #770

## What

Adds opt-in gVisor support as an additional container runtime alongside the default containerd/runc. Managed entirely through the cluster config file.

## Changes

- New `Configuration::Models::AddonsConfig::GVisor` config model
- New `Kubernetes::Software::GVisor` installer (applies RuntimeClass)
- Modified master+worker install script templates to install runsc and configure containerd when gVisor is enabled
- Modified script generators to pass gvisor_enabled flag to templates

## Usage

```yaml
addons:
  gvisor:
    enabled: true
```

After cluster creation, pods can use:
```yaml
spec:
  runtimeClassName: gvisor
```

## Verification

- [x] `crystal build --no-codegen` passes
- [x] `crystal tool format --check` passes
- [x] Follows existing code patterns (addons config + software installer)