### PR TITLE
templates: skip WireGuard mesh interfaces (NetBird, Tailscale, wg) in private network detection

### DIFF
--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -13,11 +13,15 @@ if [ "{{ private_network_enabled }}" = "true" ]; then
   DELAY=10
 
   for i in $(seq 1 $MAX_ATTEMPTS); do
-    # Simplified network interface detection
+    # Simplified network interface detection.
+    # NOTE: MTU 1280 matches WireGuard's default — mesh agents like NetBird,
+    # Tailscale, or raw wg-quick create interfaces (wt0, wg0, tailscale0,
+    # netbird0, ...) that would otherwise be picked here over the real
+    # Hetzner private vlan (enp7s0, MTU 1450). Exclude them by name.
     NETWORK_INTERFACE=$(
       ip -o link show |
         awk -F': ' '/mtu (1450|1280)/ {print $2}' |
-        grep -Ev 'cilium|lxc|br|flannel|docker|veth' |
+        grep -Ev 'cilium|lxc|br|flannel|docker|veth|wt|wg|tailscale|netbird' |
         head -n1
     )
 

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -13,11 +13,15 @@ if [ "{{ private_network_enabled }}" = "true" ]; then
   DELAY=10
 
   for i in $(seq 1 $MAX_ATTEMPTS); do
-    # Simplified network interface detection
+    # Simplified network interface detection.
+    # NOTE: MTU 1280 matches WireGuard's default — mesh agents like NetBird,
+    # Tailscale, or raw wg-quick create interfaces (wt0, wg0, tailscale0,
+    # netbird0, ...) that would otherwise be picked here over the real
+    # Hetzner private vlan (enp7s0, MTU 1450). Exclude them by name.
     NETWORK_INTERFACE=$(
       ip -o link show |
         awk -F': ' '/mtu (1450|1280)/ {print $2}' |
-        grep -Ev 'cilium|lxc|br|flannel|docker|veth' |
+        grep -Ev 'cilium|lxc|br|flannel|docker|veth|wt|wg|tailscale|netbird' |
         head -n1
     )
 


### PR DESCRIPTION
## What

Extend the exclude regex in `templates/master_install_script.sh` and
`templates/worker_install_script.sh` to skip well-known WireGuard-like
interface names (`wt|wg|tailscale|netbird`) when auto-detecting the
Hetzner private vlan.

```diff
-    grep -Ev 'cilium|lxc|br|flannel|docker|veth' |
+    grep -Ev 'cilium|lxc|br|flannel|docker|veth|wt|wg|tailscale|netbird' |
```

## Why

The current detection matches any interface with MTU 1450 (Hetzner private
vlan) **or** MTU 1280, then takes `head -n1` after the exclude regex. MTU
1280 is WireGuard's default — so on nodes running a WireGuard-based mesh
agent (NetBird, Tailscale, or raw wg-quick), the mesh interface (`wt0`,
`wg0`, `tailscale0`, `netbird0`) is a valid candidate alongside the real
private vlan. Which one wins depends on `ip link show` ordering, which is
not stable across reboots / reconciles.

When the mesh interface is picked, k3s is installed with
`--advertise-address` and `--node-ip` set to the mesh IP (usually in the
CGNAT range `100.64.0.0/10`). On a fresh cluster this works (everything
agrees on the same IP). On a reconcile of an existing HA control plane,
the etcd peer URL changes — the other members still track the master at
its original `172.x.x.x` address, the affected master can never rejoin,
and it drops out of quorum on every restart.

## Repro

1. Install NetBird (or Tailscale) DaemonSet on a temporal-* style HA k3s
   cluster previously created with `private_network.enabled: true`.
2. Wait for `wt0`/`tailscale0` to come up on every node.
3. Run `hetzner-k3s create --config cluster_config.yaml` again to add a
   worker (or for any reason that triggers master reconcile).
4. One of the masters is reinstalled with `--advertise-address=100.x.x.x`
   from `wt0` instead of `172.16.0.x` from `enp7s0`, then fails to rejoin
   etcd:
   ```
   Failed to test etcd connection: this server is a not a member of the
   etcd cluster. Found [... 172.16.0.2:2380 ... 172.16.0.3:2380 ...
   172.16.0.4:2380], expect: ... 100.73.228.222:2380
   ```

We hit this on Promova's `temporal-dev` cluster on 2026-05-28. Quorum 2/3
stayed alive on the other masters, but the same failure scaled across two
masters in one run would mean full quorum loss.

## Why this is safe

- `wt`, `wg`, `tailscale`, `netbird` are not legal prefixes of any Hetzner
  private vlan interface name (those are kernel-assigned predictable names
  like `enp7s0`, `ens10`, `eth1`).
- Existing exclude patterns (`cilium|lxc|br|flannel|docker|veth`) already
  use the same loose substring style; this PR follows the same convention.
- Behavior on clusters without a WireGuard mesh is unchanged (the new
  patterns match no interface).

## Future improvement (not in this PR)

Verifying that the picked interface's IP falls inside the configured
`private_network_subnet` would make the detection robust against any
future MTU collisions, regardless of name. The regex extension is the
minimal change to unblock mesh users today; subnet validation can be a
follow-up.

## Test plan

- [x] Build with the patch, run on a node where `wt0` is present alongside
      `enp7s0` — detection correctly picks `enp7s0`.
- [x] Run on a node without any mesh — behavior unchanged.