### PR TITLE
fix installation scripts error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     name: Publish GitHub Release Assets
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VERSION: ${{ github.ref_name }}

--- a/templates/master_install_script.sh
+++ b/templates/master_install_script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 touch /etc/initialized
 
 HOSTNAME=$(hostname -f)

--- a/templates/worker_install_script.sh
+++ b/templates/worker_install_script.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 touch /etc/initialized
 
 HOSTNAME=$(hostname -f)


### PR DESCRIPTION
The master and worker install scripts contain a line that works in bash but not in sh:
if [ ${PIPESTATUS[0]} -ne 0 ]; then
This line causes a sh: 98: Bad substitution error.
add "#!/bin/bash" to fix it.