### PR TITLE
Add Cilium network validation checks, MTU settings

### DIFF
--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -80,6 +80,8 @@ networking:
       # When specified, this file will be used instead of the default values
       # helm_values_path: "./cilium-values.yaml"
       # chart_version: "v1.17.2"
+      # mtu: 1450 # optional: Cilium underlay MTU; pod MTU is reduced by VXLAN overhead
+      # underlay_mtu: 1450 # optional: validation-only network path MTU constraint
 
   # cluster_cidr: 10.244.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for pod IPs
   # service_cidr: 10.43.0.0/16 # optional: a custom IPv4/IPv6 network CIDR to use for service IPs. Warning, if you change this, you should also change cluster_dns!

--- a/src/configuration/models/networking_config/cni_config/cilium.cr
+++ b/src/configuration/models/networking_config/cni_config/cilium.cr
@@ -4,6 +4,8 @@ class Configuration::Models::NetworkingConfig::CNIConfig::Cilium
 
   getter chart_version : String = "v1.17.2"
   getter helm_values_path : String?
+  getter mtu : Int32?
+  getter underlay_mtu : Int32?
   getter encryption_type : String? = nil
   getter routing_mode : String? = nil
   getter tunnel_protocol : String? = nil

--- a/src/configuration/validators/networking_config/cni.cr
+++ b/src/configuration/validators/networking_config/cni.cr
@@ -16,6 +16,6 @@ class Configuration::Validators::NetworkingConfig::CNI
     errors << "CNI encryption must be enabled when private networking is disabled" unless cni.encryption || private_network.enabled
     errors << "CNI mode must be either 'flannel' or 'cilium' when CNI is enabled" unless {"flannel", "cilium"}.includes?(cni.mode)
 
-    Configuration::Validators::NetworkingConfig::CNIConfig::Cilium.new(errors, cni.cilium).validate if cni.cilium?
+    Configuration::Validators::NetworkingConfig::CNIConfig::Cilium.new(errors, cni.cilium, private_network).validate if cni.cilium?
   end
 end

--- a/src/configuration/validators/networking_config/cni_config/cilium.cr
+++ b/src/configuration/validators/networking_config/cni_config/cilium.cr
@@ -1,8 +1,17 @@
+require "../../../models/networking_config/private_network"
+
 class Configuration::Validators::NetworkingConfig::CNIConfig::Cilium
+  VXLAN_OVERHEAD_BYTES       =   50
+  MIN_UNDERLAY_MTU           = 1280
+  MIN_LARGE_PACKET_POD_MTU   = 1230
+  HETZNER_PRIVATE_NETWORK_MTU = 1450
+  PUBLIC_NETWORK_MTU         = 1500
+
   getter errors : Array(String)
   getter cilium : Configuration::Models::NetworkingConfig::CNIConfig::Cilium
+  getter private_network : Configuration::Models::NetworkingConfig::PrivateNetwork
 
-  def initialize(@errors, @cilium)
+  def initialize(@errors, @cilium, @private_network)
   end
 
   def validate
@@ -18,5 +27,49 @@ class Configuration::Validators::NetworkingConfig::CNIConfig::Cilium
     if cilium.chart_version.nil? || cilium.chart_version.empty?
       errors << "Cilium chart_version is required"
     end
+
+    if cilium.helm_values_path && cilium.mtu
+      errors << "Cilium mtu is ignored when helm_values_path is set; configure MTU in the Helm values file instead"
+    end
+
+    validate_mtu
+  end
+
+  private def validate_mtu
+    mtu = cilium.mtu
+    underlay_mtu = cilium.underlay_mtu
+
+    if underlay_mtu && underlay_mtu < MIN_UNDERLAY_MTU
+      errors << "Cilium underlay_mtu must be at least #{MIN_UNDERLAY_MTU} bytes"
+    end
+
+    if underlay_mtu && mtu.nil? && cilium.helm_values_path.nil?
+      errors << "Cilium mtu must be set when underlay_mtu is configured"
+    end
+
+    return unless mtu
+
+    effective_underlay_mtu = underlay_mtu || default_underlay_mtu
+    overhead = encapsulation_overhead
+    pod_mtu = mtu - overhead
+
+    if mtu > effective_underlay_mtu
+      errors << "Cilium mtu #{mtu} exceeds the configured underlay MTU #{effective_underlay_mtu}"
+    end
+
+    if pod_mtu < MIN_LARGE_PACKET_POD_MTU
+      errors << "Cilium mtu #{mtu} leaves pod MTU #{pod_mtu} after #{overhead} bytes of encapsulation overhead; pod MTU must be at least #{MIN_LARGE_PACKET_POD_MTU}"
+    end
+  end
+
+  private def encapsulation_overhead : Int32
+    routing_mode = cilium.routing_mode || "tunnel"
+    return 0 unless routing_mode == "tunnel"
+
+    VXLAN_OVERHEAD_BYTES
+  end
+
+  private def default_underlay_mtu : Int32
+    private_network.enabled ? HETZNER_PRIVATE_NETWORK_MTU : PUBLIC_NETWORK_MTU
   end
 end

--- a/src/kubernetes/software/cilium.cr
+++ b/src/kubernetes/software/cilium.cr
@@ -3,6 +3,7 @@ require "../../configuration/main"
 require "../../util"
 require "../../util/shell"
 require "crinja"
+require "yaml"
 
 class CiliumInstallationError < Exception; end
 
@@ -24,6 +25,13 @@ class Kubernetes::Software::Cilium
   DEFAULT_ENCRYPTION_TYPE         = "wireguard"
   DEFAULT_ROUTING_MODE            = "tunnel"
   DEFAULT_TUNNEL_PROTOCOL         = "vxlan"
+  VXLAN_OVERHEAD_BYTES            =   50
+  MIN_LARGE_PACKET_POD_MTU        = 1230
+  LARGE_PING_PAYLOAD_BYTES        = 1202
+  MIN_UNDERLAY_MTU                = 1280
+  HETZNER_PRIVATE_NETWORK_MTU     = 1450
+  PUBLIC_NETWORK_MTU              = 1500
+  NETWORK_TEST_IMAGE              = "nicolaka/netshoot:latest"
 
   CILIUM_VALUES_TEMPLATE = {{ read_file("#{__DIR__}/../../../templates/cilium_values.yaml") }}
 
@@ -37,8 +45,10 @@ class Kubernetes::Software::Cilium
     log_line "Installing Cilium..."
 
     setup_helm_repo
+    validate_mtu_configuration
     install_cilium
     wait_for_cilium_ready
+    validate_network_connectivity
 
     log_line "...Cilium installed"
   end
@@ -87,6 +97,162 @@ class Kubernetes::Software::Cilium
     end
   end
 
+  private def validate_mtu_configuration
+    configured_mtu = effective_cilium_mtu
+    configured_underlay_mtu = settings.networking.cni.cilium.underlay_mtu
+    underlay_mtu = configured_underlay_mtu || default_underlay_mtu
+
+    if underlay_mtu < MIN_UNDERLAY_MTU
+      raise CiliumConfigError.new("Cilium MTU validation failed: underlay MTU #{underlay_mtu} is below Kubernetes' minimum MTU #{MIN_UNDERLAY_MTU}")
+    end
+
+    unless configured_mtu
+      if configured_underlay_mtu
+        raise CiliumConfigError.new("Cilium MTU validation failed: underlay_mtu is set but no Cilium MTU was configured in networking.cni.cilium.mtu or the Helm values file")
+      end
+
+      log_line "Skipping Cilium MTU preflight: no explicit Cilium MTU configured", log_prefix: default_log_prefix
+      return
+    end
+
+    overhead = cilium_encapsulation_overhead
+    pod_mtu = configured_mtu - overhead
+    errors = [] of String
+
+    if configured_mtu > underlay_mtu
+      errors << "configured MTU #{configured_mtu} exceeds the network path MTU #{underlay_mtu}"
+    end
+
+    if pod_mtu < MIN_LARGE_PACKET_POD_MTU
+      errors << "configured MTU #{configured_mtu} leaves pod MTU #{pod_mtu} after #{overhead} bytes of encapsulation overhead; pod MTU must be at least #{MIN_LARGE_PACKET_POD_MTU}"
+    end
+
+    nodes_result = run_shell_command(
+      "kubectl get nodes --no-headers",
+      configuration.kubeconfig_path,
+      settings.hetzner_token,
+      abort_on_error: false,
+      print_output: false
+    )
+
+    unless nodes_result.success?
+      errors << "could not inspect Kubernetes nodes before installing Cilium: #{nodes_result.output}"
+    end
+
+    unless errors.empty?
+      raise CiliumConfigError.new("Cilium MTU validation failed:\n - #{errors.join("\n - ")}")
+    end
+
+    source = configured_underlay_mtu ? "configured underlay_mtu" : "default underlay MTU"
+    log_line "Cilium MTU preflight passed: configured MTU #{configured_mtu}, pod MTU #{pod_mtu}, #{source} #{underlay_mtu}", log_prefix: default_log_prefix
+  end
+
+  private def validate_network_connectivity
+    command = <<-BASH
+set -euo pipefail
+
+namespace="#{DEFAULT_NAMESPACE}"
+image="#{NETWORK_TEST_IMAGE}"
+large_payload="#{LARGE_PING_PAYLOAD_BYTES}"
+large_packet="#{MIN_LARGE_PACKET_POD_MTU}"
+run_id="cilium-netcheck-$(date +%s)-$RANDOM"
+src_pod="${run_id}-src"
+dst_pod="${run_id}-dst"
+small_ping_output="/tmp/${run_id}-small-ping.out"
+large_ping_output="/tmp/${run_id}-large-ping.out"
+
+cleanup() {
+  kubectl -n "$namespace" delete pod "$src_pod" "$dst_pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  rm -f "$small_ping_output" "$large_ping_output"
+}
+trap cleanup EXIT
+
+nodes="$(kubectl get nodes --no-headers | awk '$2 ~ /^Ready/ {print $1}' | head -n 2)"
+node_count="$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+if [ "$node_count" -lt 2 ]; then
+  echo "Network validation requires at least two Ready nodes for a cross-node Cilium MTU test; found $node_count." >&2
+  exit 1
+fi
+
+src_node="$(printf '%s\n' "$nodes" | sed -n '1p')"
+dst_node="$(printf '%s\n' "$nodes" | sed -n '2p')"
+
+cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $src_pod
+  namespace: $namespace
+  labels:
+    app.kubernetes.io/name: cilium-network-validation
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  nodeName: $src_node
+  tolerations:
+  - operator: Exists
+  containers:
+  - name: netshoot
+    image: $image
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "sleep 3600"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $dst_pod
+  namespace: $namespace
+  labels:
+    app.kubernetes.io/name: cilium-network-validation
+spec:
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  nodeName: $dst_node
+  tolerations:
+  - operator: Exists
+  containers:
+  - name: netshoot
+    image: $image
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "sleep 3600"]
+EOF
+
+kubectl -n "$namespace" wait --for=condition=Ready "pod/$src_pod" "pod/$dst_pod" --timeout=180s >/dev/null
+dst_ip="$(kubectl -n "$namespace" get pod "$dst_pod" -o jsonpath='{.status.podIP}')"
+
+if [ -z "$dst_ip" ]; then
+  echo "Network validation failed: destination pod did not receive a pod IP." >&2
+  exit 1
+fi
+
+if ! kubectl -n "$namespace" exec "$src_pod" -- ping -c 3 -W 2 "$dst_ip" >"$small_ping_output" 2>&1; then
+  echo "Network validation failed: small packet ping from $src_pod on $src_node to $dst_pod on $dst_node ($dst_ip) failed." >&2
+  cat "$small_ping_output" >&2
+  exit 1
+fi
+
+if ! kubectl -n "$namespace" exec "$src_pod" -- ping -c 3 -W 2 -M do -s "$large_payload" "$dst_ip" >"$large_ping_output" 2>&1; then
+  echo "Network validation failed: ${large_packet}B large packet ping from $src_pod on $src_node to $dst_pod on $dst_node ($dst_ip) failed. Check Cilium MTU, VXLAN overhead, and the network path MTU." >&2
+  cat "$large_ping_output" >&2
+  exit 1
+fi
+
+echo "Cilium cross-node network validation passed: small ping and ${large_packet}B large packet ping from $src_node to $dst_node."
+BASH
+
+    result = run_shell_command(
+      command,
+      configuration.kubeconfig_path,
+      settings.hetzner_token,
+      abort_on_error: false
+    )
+
+    unless result.success?
+      raise CiliumInstallationError.new("Failed Cilium network validation: #{result.output}")
+    end
+  end
+
   private def build_helm_command(helm_values_path : String)
     version = sanitize_version(settings.networking.cni.cilium.chart_version)
 
@@ -104,6 +270,7 @@ class Kubernetes::Software::Cilium
     cilium_config = settings.networking.cni.cilium
 
     template_vars = {
+      mtu:                     cilium_config.mtu,
       encryption_enabled:      settings.networking.cni.encryption,
       encryption_type:         cilium_config.encryption_type || DEFAULT_ENCRYPTION_TYPE,
       routing_mode:            cilium_config.routing_mode || DEFAULT_ROUTING_MODE,
@@ -121,6 +288,49 @@ class Kubernetes::Software::Cilium
     }
 
     Crinja.render(CILIUM_VALUES_TEMPLATE, template_vars)
+  end
+
+  private def effective_cilium_mtu : Int32?
+    helm_values_path = settings.networking.cni.cilium.helm_values_path
+    return mtu_from_helm_values(helm_values_path) if helm_values_path && File.exists?(helm_values_path)
+
+    settings.networking.cni.cilium.mtu
+  end
+
+  private def mtu_from_helm_values(helm_values_path : String) : Int32?
+    values = YAML.parse(File.read(helm_values_path))
+    mtu_node = values["MTU"]? || values["mtu"]?
+    return unless mtu_node
+
+    mtu = yaml_value_to_i(mtu_node)
+    raise "MTU must be an integer" unless mtu
+
+    mtu
+  rescue ex
+    raise CiliumConfigError.new("Failed to parse Cilium helm values file '#{helm_values_path}' for MTU validation: #{ex.message}")
+  end
+
+  private def yaml_value_to_i(value : YAML::Any) : Int32?
+    begin
+      value.as_i
+    rescue
+      begin
+        value.as_s.to_i?
+      rescue
+        nil
+      end
+    end
+  end
+
+  private def default_underlay_mtu : Int32
+    settings.networking.private_network.enabled ? HETZNER_PRIVATE_NETWORK_MTU : PUBLIC_NETWORK_MTU
+  end
+
+  private def cilium_encapsulation_overhead : Int32
+    routing_mode = settings.networking.cni.cilium.routing_mode || DEFAULT_ROUTING_MODE
+    return 0 unless routing_mode == "tunnel"
+
+    VXLAN_OVERHEAD_BYTES
   end
 
   private def build_hubble_metrics_array(custom_metrics : String?) : Array(String)

--- a/templates/cilium_values.yaml
+++ b/templates/cilium_values.yaml
@@ -10,6 +10,9 @@ encryption:
 # Routing and tunneling
 routingMode: {{ routing_mode }}
 tunnelProtocol: {{ tunnel_protocol }}
+{% if mtu %}
+MTU: {{ mtu }}
+{% endif %}
 
 # IPAM settings
 ipam:


### PR DESCRIPTION
## Summary

Adds MTU and connectivity validation to the Cilium installation flow to catch broken network configurations before they reach production.

## Changes

- Adds `networking.cni.cilium.mtu` and `underlay_mtu` configuration fields.
- Validates Cilium MTU settings during configuration loading.
- Runs a pre-deployment MTU validation before `helm upgrade --install`.
- Reads MTU from custom Cilium Helm values when `helm_values_path` is used.
- Adds post-rollout cross-node network validation after `kubectl rollout status ds cilium`.
- Gates installation success on both:
  - small packet pod-to-pod ping
  - large 1230B pod-to-pod ping with DF set

## Why

This prevents Cilium installs from succeeding when the configured MTU does not fit the network path MTU after VXLAN encapsulation overhead. It also avoids relying only on rollout status or small pings, which can pass while larger packets are still blackholed.

## Validation

- `git diff --check`
- `crystal build src/hetzner-k3s.cr --no-codegen` using Crystal 1.20.0 Docker image

The build passes with only existing `Time.monotonic` deprecation warnings.