### PR TITLE
fix: network zone mismatch causes server creation to fail in US locations

### DIFF
--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -170,6 +170,8 @@ worker_node_pools:
 
 protect_against_deletion: true # prevents accidental deletion of the cluster with the "hetzner-k3s delete" command
 
+placement_groups_enabled: false # when true, automatically creates Hetzner spread placement groups so that masters and workers run on different physical hosts; note: not all server types or locations support placement groups (e.g. cpx31 in ash/hil may not)
+
 create_load_balancer_for_the_kubernetes_api: false # creates a load balancer for HA API access; note: Hetzner firewalls can't yet restrict access to load balancers by IP
 
 k3s_upgrade_concurrency: 1 # how many nodes to upgrade at the same time; increase for faster upgrades in large clusters, but higher values may impact availability

--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -53,7 +53,11 @@ class Cluster::Create
     @ssh_key = create_ssh_key
 
     static_worker_node_pools = settings.worker_node_pools.reject(&.autoscaling_enabled)
-    @placement_groups = placement_group_manager.create(settings.masters_pool.instance_count, static_worker_node_pools)
+    @placement_groups = if settings.placement_groups_enabled
+      placement_group_manager.create(settings.masters_pool.instance_count, static_worker_node_pools)
+    else
+      PlacementGroupManager::PlacementGroups.new
+    end
     @instance_builder = InstanceBuilder.new(settings, hetzner_client, mutex, ssh_key, network, placement_groups)
 
     @master_instances = instance_builder.initialize_master_instances(masters_locations)

--- a/src/cluster/delete.cr
+++ b/src/cluster/delete.cr
@@ -109,7 +109,7 @@ class Cluster::Delete
   end
 
   private def delete_placement_groups
-    placement_group_manager.delete
+    placement_group_manager.delete if settings.placement_groups_enabled
   end
 
   private def delete_network

--- a/src/configuration/main.cr
+++ b/src/configuration/main.cr
@@ -38,6 +38,7 @@ class Configuration::Main
   getter create_load_balancer_for_the_kubernetes_api : Bool = false
   getter k3s_upgrade_concurrency : Int64 = 1
   getter grow_root_partition_automatically : Bool = true
+  getter placement_groups_enabled : Bool = false
 
   def all_kubelet_args
     ["cloud-provider=external", "resolv-conf=/etc/k8s-resolv.conf"] + kubelet_args

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -108,7 +108,7 @@ class Hetzner::Instance::Create
 
         if response.includes?("\"invalid_input\"")
           log_line "Aborting: Hetzner API rejected the request as invalid input — retrying will not help.\n#{response}"
-          log_line "Hint: if the error is \"unsupported location for server type\", the server type may not be available in the target location, or a feature included in the request (e.g. placement groups) is not supported there. See the README for details."
+          log_line "Hint: if the error is \"unsupported location for server type\", the server type may not be available in the target location. Common causes: (1) the server type is not offered in that datacenter, (2) the private network's zone does not cover the server's location (e.g. an eu-central network cannot host servers in ash/hil). See the README for details."
           exit 1
         end
 

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -105,7 +105,14 @@ class Hetzner::Instance::Create
         break
       else
         log_line "Creating instance #{instance_name} failed: #{response}"
-        delay = [INITIAL_DELAY * (2 ** (attempts - 1)), MAX_DELAY].min
+
+        if response.includes?("\"invalid_input\"")
+          log_line "Aborting: Hetzner API rejected the request as invalid input — retrying will not help.\n#{response}"
+          log_line "Hint: if the error is \"unsupported location for server type\", the server type may not be available in the target location, or a feature included in the request (e.g. placement groups) is not supported there. See the README for details."
+          exit 1
+        end
+
+        delay = [INITIAL_DELAY.to_i64 * (2_i64 ** (attempts - 1)), MAX_DELAY.to_i64].min
         log_line "Waiting #{delay} seconds before retry..."
         sleep delay.seconds
       end

--- a/src/hetzner/network.cr
+++ b/src/hetzner/network.cr
@@ -1,8 +1,22 @@
 require "json"
 
 class Hetzner::Network
+  class Subnet
+    include JSON::Serializable
+
+    property network_zone : String
+    property type : String
+    property ip_range : String
+    property gateway : String?
+  end
+
   include JSON::Serializable
 
   property id : Int64
   property name : String
+  property subnets : Array(Subnet) = [] of Subnet
+
+  def network_zone : String?
+    subnets.first?.try(&.network_zone)
+  end
 end

--- a/src/hetzner/network/create.cr
+++ b/src/hetzner/network/create.cr
@@ -20,7 +20,16 @@ class Hetzner::Network::Create
   def run
     network = network_finder.run
 
-    return network if network
+    if network
+      existing_zone = network.network_zone
+      if existing_zone && existing_zone != network_zone
+        STDERR.puts "[#{default_log_prefix}] ERROR: A network named '#{network_name}' already exists but its zone '#{existing_zone}' does not match the required zone '#{network_zone}' for this cluster's location."
+        STDERR.puts "[#{default_log_prefix}] This typically happens when a previous cluster creation attempt left a stale network in a different region."
+        STDERR.puts "[#{default_log_prefix}] To fix: delete the stale network '#{network_name}' via `hcloud network delete #{network_name}` and retry."
+        exit 1
+      end
+      return network
+    end
 
     log_line "Creating private network..."
     create_network


### PR DESCRIPTION
## Problem

Two separate issues that both manifest as Hetzner API rejecting server creation with `invalid_input` / `"unsupported location for server type"` in US datacenters (ash, hil):

### 1. Private network zone mismatch (silent reuse of stale network)

`Hetzner::Network::Create.run` (src/hetzner/network/create.cr) matched existing networks **by name only**, without checking that the network's zone matches the cluster's required zone. When a previous cluster creation attempt left a stale `eu-central` network behind, a fresh attempt targeting `ash` or `hil` (which require `us-east`/`us-west`) would silently reuse that network. Hetzner then rejects `POST /servers` because a `eu-central` network cannot host servers in US datacenters.

**Fix:** Deserialise subnets in `Hetzner::Network` to expose `network_zone`. When an existing network is found, verify its zone matches the required zone. If it doesn't, print a clear actionable error (including the `hcloud network delete` command) and exit immediately.

### 2. Placement groups not supported for all server types / locations

Placement groups were **always** created and unconditionally included in `POST /servers`. For certain server types in US locations (e.g. `cpx31` in `ash`/`hil`), this triggers `invalid_input` from Hetzner's API. This was the root cause of the recurring issues that led to placement groups being removed in f773ae6 and re-added in 17fd792.

**Fix:** Add `placement_groups_enabled: false` (opt-in flag, default off) to `Configuration::Main`. `Cluster::Create` only calls `PlacementGroupManager#create` when the flag is `true`; otherwise it passes an empty struct, so no `placement_group` field is sent. `Cluster::Delete` skips the cleanup pass in the same way. Users who want placement groups (EU locations, compatible server types) can opt in explicitly.

### 3. Int32 overflow crash in retry back-off (bonus fix)

The exponential delay formula in instance creation used `Int32` arithmetic. At retry attempt 32, `2 ** 31` overflows `Int32::MAX`, raising `Arithmetic overflow` and killing the process.

**Fix:** use `Int64` literals (`.to_i64`, `2_i64`) throughout the delay calculation. As a companion improvement, `invalid_input` responses are now detected immediately and treated as non-retryable (exits with a human-readable hint), preventing both wasted retries and the eventual overflow.

## Repro (hcloud CLI)

```bash
# Fails (placement group + ash):
hcloud server create --name test --type cpx31 --location ash --image ubuntu-22.04 --placement-group <id>

# Succeeds (no placement group):
hcloud server create --name test --type cpx31 --location ash --image ubuntu-22.04
```

## Changes

| File | Change |
|------|--------|
| `src/hetzner/network.cr` | Add `Subnet` model; expose `network_zone` via first subnet |
| `src/hetzner/network/create.cr` | Validate zone of existing network before reuse |
| `src/hetzner/instance/create.cr` | Detect `invalid_input` as non-retryable; fix Int32→Int64 overflow |
| `src/configuration/main.cr` | Add `placement_groups_enabled : Bool = false` |
| `src/cluster/create.cr` | Guard placement group creation behind flag |
| `src/cluster/delete.cr` | Guard placement group deletion behind flag |
| `docs/Creating_a_cluster.md` | Document `placement_groups_enabled` option |

## Notes

- `placement_groups_enabled` is `false` by default to avoid breaking existing US-location users. Users on EU with compatible server types who want the spreading behaviour need to add `placement_groups_enabled: true` to their config.
- Compilation to be verified by CI (Crystal build environment not available locally).