### PR TITLE
feat: support Tailscale for administrative access

### DIFF
--- a/docs/Creating_a_cluster.md
+++ b/docs/Creating_a_cluster.md
@@ -24,6 +24,10 @@ networking:
     public_key_path: "~/.ssh/id_ed25519.pub"
     private_key_path: "~/.ssh/id_ed25519"
     # existing_ssh_key_name: "my-existing-key" # optional: use an existing SSH key in Hetzner instead of creating a new one
+  # tailscale: # optional: private admin access to nodes and the Kubernetes API via a Tailscale tailnet, see https://github.com/vitobotta/hetzner-k3s/blob/main/docs/Tailscale_integration.md
+  #   enabled: false
+  #   hostname_suffix: "my-tailnet.ts.net" # required when enabled
+  #   auth_key: "tskey-auth-..." # optional: defaults to the TAILSCALE_AUTH_KEY environment variable
   allowed_networks:
     ssh:
       - 0.0.0.0/0

--- a/docs/Tailscale_integration.md
+++ b/docs/Tailscale_integration.md
@@ -1,0 +1,59 @@
+# Tailscale integration
+
+hetzner-k3s can install [Tailscale](https://tailscale.com) on every cluster node during provisioning and join them to your tailnet. This gives you a private administrative path to the nodes (SSH) and to the Kubernetes API, without exposing them to the public internet or maintaining CIDR allowlists for changing IPs (home, coworking, travel).
+
+When enabled:
+
+1. Each node installs Tailscale in cloud-init and joins the tailnet as `<instance-name>.<hostname_suffix>` (MagicDNS name).
+2. All SSH connections made by hetzner-k3s itself (provisioning, upgrades, `run` commands) go through the tailnet instead of public or private IPs.
+3. The API server certificate gets a TLS SAN for each master's Tailscale hostname, and the generated kubeconfig points to `https://<first-master>.<hostname_suffix>:6443`.
+
+## Prerequisites
+
+- A Tailscale account with MagicDNS enabled (Settings > DNS > Enable MagicDNS).
+- A **reusable, pre-approved** auth key. Nodes are long-lived servers, so ephemeral keys are not suitable. Tagged keys are recommended for ACL scoping (e.g. `tag:k8s-nodes`). Generate one at <https://login.tailscale.com/admin/settings/keys>.
+- The machine running hetzner-k3s must be connected to the same tailnet and have the `tailscale` CLI installed, since hetzner-k3s checks peer registration with `tailscale status` before connecting.
+
+## Configuration
+
+```yaml
+networking:
+  tailscale:
+    enabled: true
+    hostname_suffix: "my-tailnet.ts.net" # your tailnet's MagicDNS domain, found in the admin console under DNS
+    # auth_key: "tskey-auth-..." # optional: defaults to the TAILSCALE_AUTH_KEY environment variable
+```
+
+The auth key can be supplied in two ways:
+
+| Method | How |
+|--------|-----|
+| Environment variable (recommended) | `export TAILSCALE_AUTH_KEY="tskey-auth-..."` |
+| Config file | `auth_key: "tskey-auth-..."` in the `tailscale:` block |
+
+The key is written to `/run/tailscale-authkey` (mode `0600`, tmpfs) on each node during cloud-init and deleted immediately after `tailscale up` runs. It never touches the node's persistent disk.
+
+## Locking down public access
+
+Tailscale requires **no inbound firewall rules**: connections are established outbound only. Once nodes are reachable over the tailnet, you can restrict the public SSH and API firewalls, since the current-IP validation in `allowed_networks` is skipped when Tailscale is enabled:
+
+```yaml
+networking:
+  tailscale:
+    enabled: true
+    hostname_suffix: "my-tailnet.ts.net"
+  allowed_networks:
+    ssh:
+      - 10.0.0.0/8 # effectively blocks public SSH; real access goes over the tailnet
+    api:
+      - 10.0.0.0/8 # same for the Kubernetes API on port 6443
+```
+
+With this setup, `kubectl` works from any machine connected to the tailnet, because the kubeconfig points to the master's MagicDNS hostname and the API server certificate includes it as a SAN.
+
+## Notes and limitations
+
+- Nodes are configured with `--accept-dns=false`, so their own DNS resolution is unchanged and does not depend on `tailscaled`. Only the machines you administer from need MagicDNS resolution.
+- Node registration adds a short delay to first boot. hetzner-k3s automatically waits longer for SSH when Tailscale is enabled.
+- **Cluster deletion does not remove nodes from your tailnet.** Remove stale machines from the [admin console](https://login.tailscale.com/admin/machines) after deleting a cluster. If you recreate a cluster with the same names while stale entries exist, Tailscale appends a numeric suffix to the new nodes' DNS names, which breaks Tailscale-based SSH access.
+- IPv6-only nodes (no public IPv4) are not covered by this integration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Recommendations: Recommendations.md
     - Masters in Different Locations: Masters_in_different_locations.md
     - Private Clusters: Private_clusters_with_public_network_interface_disabled.md
+    - Tailscale Integration: Tailscale_integration.md
     - Floating IP Egress: Floating_IP_egress.md
     - Resizing Root Partition: Resizing_root_partition_with_post_create_commands.md
   - Reference:

--- a/src/cluster/create.cr
+++ b/src/cluster/create.cr
@@ -18,7 +18,8 @@ class Cluster::Create
     Util::SSH.new(
       settings.networking.ssh.private_key_path,
       settings.networking.ssh.public_key_path,
-      settings.networking.ssh.use_private_ip
+      settings.networking.ssh.use_private_ip,
+      tailscale_hostname_suffix: settings.networking.tailscale.ssh_hostname_suffix
     )
   end
   private getter network : Hetzner::Network?

--- a/src/cluster/delete.cr
+++ b/src/cluster/delete.cr
@@ -70,6 +70,16 @@ class Cluster::Delete
     delete_network if settings.networking.private_network.enabled
     delete_firewall if settings.networking.private_network.enabled || !settings.networking.public_network.use_local_firewall
     delete_ssh_key
+    warn_about_tailscale_cleanup
+  end
+
+  # hetzner-k3s cannot remove nodes from the tailnet on its own. Stale Tailscale
+  # machines cause new nodes with the same hostnames to get a numeric suffix,
+  # which breaks Tailscale-based SSH access on a freshly created cluster.
+  private def warn_about_tailscale_cleanup
+    return unless settings.networking.tailscale.enabled
+
+    log_line "Remember to remove this cluster's nodes from your tailnet at https://login.tailscale.com/admin/machines"
   end
 
   private def cleanup_external_nodes

--- a/src/cluster/run.cr
+++ b/src/cluster/run.cr
@@ -255,7 +255,8 @@ class Cluster::Run
       ssh = Util::SSH.new(
         settings.networking.ssh.private_key_path,
         settings.networking.ssh.public_key_path,
-        settings.networking.ssh.use_private_ip
+        settings.networking.ssh.use_private_ip,
+        tailscale_hostname_suffix: settings.networking.tailscale.ssh_hostname_suffix
       )
       {ssh, settings.networking.ssh.port, settings.networking.ssh.use_agent, false}
     end

--- a/src/configuration/models/networking.cr
+++ b/src/configuration/models/networking.cr
@@ -3,6 +3,7 @@ require "./networking_config/allowed_networks"
 require "./networking_config/private_network"
 require "./networking_config/public_network"
 require "./networking_config/ssh"
+require "./networking_config/tailscale"
 
 module Configuration
   module Models
@@ -15,6 +16,7 @@ module Configuration
       getter public_network : ::Configuration::Models::NetworkingConfig::PublicNetwork = ::Configuration::Models::NetworkingConfig::PublicNetwork.new
       getter allowed_networks : ::Configuration::Models::NetworkingConfig::AllowedNetworks = ::Configuration::Models::NetworkingConfig::AllowedNetworks.new
       getter ssh : ::Configuration::Models::NetworkingConfig::SSH = ::Configuration::Models::NetworkingConfig::SSH.new
+      getter tailscale : ::Configuration::Models::NetworkingConfig::Tailscale = ::Configuration::Models::NetworkingConfig::Tailscale.new
       getter node_port_firewall_enabled : Bool = true
       getter node_port_range : String = "30000-32767"
       getter cluster_cidr : String = "10.244.0.0/16"

--- a/src/configuration/models/networking_config/tailscale.cr
+++ b/src/configuration/models/networking_config/tailscale.cr
@@ -1,0 +1,17 @@
+class Configuration::Models::NetworkingConfig::Tailscale
+  include YAML::Serializable
+  include YAML::Serializable::Unmapped
+
+  getter enabled : Bool = false
+  getter hostname_suffix : String = ""
+  getter auth_key : String = ENV.fetch("TAILSCALE_AUTH_KEY", "")
+
+  def initialize
+  end
+
+  # Suffix used to route SSH connections through the tailnet.
+  # Returns an empty string when Tailscale is disabled, so SSH falls back to IPs.
+  def ssh_hostname_suffix : String
+    enabled ? hostname_suffix : ""
+  end
+end

--- a/src/configuration/validators/networking.cr
+++ b/src/configuration/validators/networking.cr
@@ -11,6 +11,7 @@ require "./networking_config/node_port_range"
 require "./networking_config/private_network"
 require "./networking_config/public_network"
 require "./networking_config/ssh"
+require "./networking_config/tailscale"
 
 class Configuration::Validators::Networking
   getter errors : Array(String)
@@ -28,11 +29,12 @@ class Configuration::Validators::Networking
     Configuration::Validators::NetworkingConfig::AllowedNetworks.new(
       errors,
       networking.allowed_networks,
-      skip_current_ip_validation: skip_current_ip_validation
+      skip_current_ip_validation: skip_current_ip_validation || networking.tailscale.enabled
     ).validate
     Configuration::Validators::NetworkingConfig::NodePortRange.new(errors, networking.node_port_range).validate
     Configuration::Validators::NetworkingConfig::PrivateNetwork.new(errors, private_network, hetzner_client).validate
     Configuration::Validators::NetworkingConfig::PublicNetwork.new(errors, networking.public_network, settings).validate
     Configuration::Validators::NetworkingConfig::SSH.new(errors, networking.ssh, hetzner_client, settings.cluster_name).validate
+    Configuration::Validators::NetworkingConfig::Tailscale.new(errors, networking.tailscale).validate
   end
 end

--- a/src/configuration/validators/networking_config/tailscale.cr
+++ b/src/configuration/validators/networking_config/tailscale.cr
@@ -1,0 +1,28 @@
+require "../../models/networking_config/tailscale"
+
+class Configuration::Validators::NetworkingConfig::Tailscale
+  getter errors : Array(String)
+  getter tailscale : Configuration::Models::NetworkingConfig::Tailscale
+
+  def initialize(@errors, @tailscale)
+  end
+
+  def validate
+    return unless tailscale.enabled
+
+    validate_hostname_suffix
+    validate_auth_key
+  end
+
+  private def validate_hostname_suffix
+    if tailscale.hostname_suffix.empty?
+      errors << "tailscale.hostname_suffix is required when tailscale is enabled (e.g. \"my-tailnet.ts.net\", found in the Tailscale admin console under DNS)"
+    end
+  end
+
+  private def validate_auth_key
+    if tailscale.auth_key.empty?
+      errors << "A Tailscale auth key is required when tailscale is enabled. Set tailscale.auth_key in the configuration or the TAILSCALE_AUTH_KEY environment variable."
+    end
+  end
+end

--- a/src/hetzner/instance.cr
+++ b/src/hetzner/instance.cr
@@ -29,6 +29,10 @@ class Hetzner::Instance
     /-master\d+/ =~ name
   end
 
+  def tailscale_host(suffix : String) : String
+    "#{name}.#{suffix}"
+  end
+
   def initialize(id : Int32, status : String, instance_name : String, internal_ip : String, external_ip : String)
     @id = id
     @status = status

--- a/src/hetzner/instance/cloud_init_generator.cr
+++ b/src/hetzner/instance/cloud_init_generator.cr
@@ -31,6 +31,7 @@ class Hetzner::Instance::CloudInitGenerator
       eth1_str:                               eth1,
       firewall_files:                         firewall_files,
       ssh_files:                              ssh_files,
+      tailscale_files:                        tailscale_files,
       init_files:                             init_file_content,
       allowed_kubernetes_api_networks_config: allowed_kubernetes_api_networks_config,
       allowed_ssh_networks_config:            allowed_ssh_networks_config,
@@ -144,6 +145,19 @@ class Hetzner::Instance::CloudInitGenerator
     YAML
   end
 
+  private def tailscale_files
+    return "" unless @settings.networking.tailscale.enabled
+
+    # The auth key is written to /run (a tmpfs mount) with mode 0600 and
+    # deleted right after `tailscale up`, so it does not persist on disk.
+    <<-YAML
+    - content: |
+        #{@settings.networking.tailscale.auth_key}
+      path: /run/tailscale-authkey
+      permissions: '0600'
+    YAML
+  end
+
   private def growpart
     @snapshot_os == "microos" ? <<-YAML
     growpart:
@@ -204,9 +218,12 @@ class Hetzner::Instance::CloudInitGenerator
     commands = [
       "hostnamectl set-hostname $(curl http://169.254.169.254/hetzner/v1/metadata/hostname)",
       "update-crypto-policies --set DEFAULT:SHA1 || true",
-      "/etc/configure_ssh.sh",
-      "echo \"nameserver 8.8.8.8\" > /etc/k8s-resolv.conf",
     ]
+
+    commands.concat(tailscale_commands) if @settings.networking.tailscale.enabled
+
+    commands << "/etc/configure_ssh.sh"
+    commands << "echo \"nameserver 8.8.8.8\" > /etc/k8s-resolv.conf"
 
     if !@settings.networking.private_network.enabled && @settings.networking.public_network.use_local_firewall
       commands << "/usr/local/bin/firewall.sh setup"
@@ -214,6 +231,19 @@ class Hetzner::Instance::CloudInitGenerator
     end
 
     commands
+  end
+
+  # Installs Tailscale and joins the node to the tailnet as
+  # `<instance-name>.<hostname_suffix>`, right after the hostname is set.
+  # `--accept-dns=false` keeps the node's DNS resolution unchanged: MagicDNS
+  # names only need to resolve on the machine running hetzner-k3s, not on the
+  # nodes themselves.
+  private def tailscale_commands
+    [
+      "curl -fsSL https://tailscale.com/install.sh | sh",
+      "tailscale up --authkey=$(cat /run/tailscale-authkey) --hostname=$(hostname) --accept-routes && rm -f /run/tailscale-authkey",
+      "tailscale set --accept-dns=false",
+    ]
   end
 
   private def generate_post_create_commands_str

--- a/src/hetzner/instance/create.cr
+++ b/src/hetzner/instance/create.cr
@@ -17,6 +17,10 @@ class Hetzner::Instance::Create
   INITIAL_DELAY =  1 # 1 second
   MAX_DELAY     = 60
 
+  # Nodes take longer to become reachable via SSH when they first need to
+  # install Tailscale and register with the tailnet during cloud-init.
+  TAILSCALE_SSH_WAIT_ATTEMPTS = 60
+
   getter instance_name : String
 
   private getter settings : Configuration::Main
@@ -37,7 +41,8 @@ class Hetzner::Instance::Create
   private getter ssh : Configuration::Models::NetworkingConfig::SSH
   private getter mutex : Mutex
   private getter ssh_client : Util::SSH do
-    Util::SSH.new(ssh.private_key_path, ssh.public_key_path, ssh.use_private_ip)
+    Util::SSH.new(ssh.private_key_path, ssh.public_key_path, ssh.use_private_ip,
+      tailscale_hostname_suffix: settings.networking.tailscale.ssh_hostname_suffix)
   end
   private property instance_existed : Bool = false
   private property powering_on_count : Int32 = 0
@@ -139,7 +144,7 @@ class Hetzner::Instance::Create
 
       next unless attached_to_network?(instance)
 
-      ssh_client.wait_for_instance instance, ssh.port, ssh.use_agent, "echo ready", "ready"
+      ssh_client.wait_for_instance instance, ssh.port, ssh.use_agent, "echo ready", "ready", ssh_wait_attempts
       ready = true
     end
 
@@ -164,6 +169,10 @@ class Hetzner::Instance::Create
 
   private def private_network_enabled?
     settings.networking.private_network.enabled
+  end
+
+  private def ssh_wait_attempts
+    settings.networking.tailscale.enabled ? TAILSCALE_SSH_WAIT_ATTEMPTS : Util::SSH::DEFAULT_MAX_ATTEMPTS
   end
 
   private def needs_powering_on?(instance)

--- a/src/k3s.cr
+++ b/src/k3s.cr
@@ -59,7 +59,8 @@ module K3s
       ssh_client = ::Util::SSH.new(
         settings.networking.ssh.private_key_path,
         settings.networking.ssh.public_key_path,
-        settings.networking.ssh.use_private_ip
+        settings.networking.ssh.use_private_ip,
+        tailscale_hostname_suffix: settings.networking.tailscale.ssh_hostname_suffix
       )
 
       result = ssh_client.run(
@@ -82,7 +83,8 @@ module K3s
       ssh_client = ::Util::SSH.new(
         settings.networking.ssh.private_key_path,
         settings.networking.ssh.public_key_path,
-        settings.networking.ssh.use_private_ip
+        settings.networking.ssh.use_private_ip,
+        tailscale_hostname_suffix: settings.networking.tailscale.ssh_hostname_suffix
       )
 
       result = ssh_client.run(

--- a/src/kubernetes/kubeconfig_manager.cr
+++ b/src/kubernetes/kubeconfig_manager.cr
@@ -35,11 +35,13 @@ class Kubernetes::KubeconfigManager
     end
 
     masters.each_with_index do |master, index|
-      master_ip_address = if @settings.networking.ssh.use_private_ip
-        master.private_ip_address
-      else
-        @settings.networking.public_network.ipv4 ? master.public_ip_address : master.private_ip_address
-      end
+      master_ip_address = if @settings.networking.tailscale.enabled
+                            master.tailscale_host(@settings.networking.tailscale.hostname_suffix)
+                          elsif @settings.networking.ssh.use_private_ip
+                            master.private_ip_address
+                          else
+                            @settings.networking.public_network.ipv4 ? master.public_ip_address : master.private_ip_address
+                          end
       master_kubeconfig_path = "#{kubeconfig_path}-#{master.name}"
       master_kubeconfig = kubeconfig
         .gsub("server: https://127.0.0.1:6443", "server: https://#{master_ip_address}:6443")
@@ -76,6 +78,9 @@ class Kubernetes::KubeconfigManager
     masters.each do |master|
       sans << "--tls-san=#{master.private_ip_address}"
       sans << "--tls-san=#{master.public_ip_address}"
+      if @settings.networking.tailscale.enabled
+        sans << "--tls-san=#{master.tailscale_host(@settings.networking.tailscale.hostname_suffix)}"
+      end
     end
 
     sans.uniq.sort.join(" ")

--- a/src/util/ssh.cr
+++ b/src/util/ssh.cr
@@ -1,3 +1,4 @@
+require "json"
 require "retriable"
 require "tasker"
 require "../util"
@@ -21,8 +22,9 @@ class Util::SSH
   getter public_ssh_key_path : String
   getter prefer_private_ip : Bool = false
   getter user : String = "root"
+  getter tailscale_hostname_suffix : String = ""
 
-  def initialize(@private_ssh_key_path, @public_ssh_key_path = "", @prefer_private_ip = false, @user = "root")
+  def initialize(@private_ssh_key_path, @public_ssh_key_path = "", @prefer_private_ip = false, @user = "root", @tailscale_hostname_suffix = "")
   end
 
   def self.calculate_fingerprint(public_ssh_key_path)
@@ -80,18 +82,13 @@ class Util::SSH
 
   # Run a command on a remote instance via SSH
   def run(instance, port, command, use_ssh_agent, print_output = true, disable_log_prefix = false, capture_output = false)
-    host_ip_address = instance.host_ip_address(prefer_private_ip)
-    raise "Instance #{instance.name} has no IP address" unless host_ip_address
-
-    if prefer_private_ip && instance.private_net.try(&.first?).try(&.ip).nil?
-      log_line "WARNING: Instance #{instance.name} has no private IP, falling back to public IP", log_prefix: "Instance #{instance.name}"
-    end
+    host = resolve_host(instance)
 
     debug = ENV.fetch("DEBUG", "false") == "true"
     log_level = debug ? "DEBUG" : "ERROR"
 
     ssh_args = build_ssh_args(
-      host_ip_address: host_ip_address,
+      host_ip_address: host,
       port: port,
       command: command,
       use_ssh_agent: use_ssh_agent,
@@ -178,5 +175,45 @@ class Util::SSH
 
   private def default_log_prefix
     "+"
+  end
+
+  private def tailscale? : Bool
+    !tailscale_hostname_suffix.empty?
+  end
+
+  private def resolve_host(instance)
+    return resolve_ip_host(instance) unless tailscale?
+
+    tailscale_hostname = instance.tailscale_host(tailscale_hostname_suffix)
+    return tailscale_hostname if tailscale_peer_online?(tailscale_hostname)
+
+    log_line "Waiting for #{tailscale_hostname} to register with Tailscale...", log_prefix: "Instance #{instance.name}"
+    raise IO::Error.new("Tailscale peer #{tailscale_hostname} not yet online")
+  end
+
+  private def resolve_ip_host(instance)
+    host_ip_address = instance.host_ip_address(prefer_private_ip)
+    raise "Instance #{instance.name} has no IP address" unless host_ip_address
+
+    if prefer_private_ip && instance.private_net.try(&.first?).try(&.ip).nil?
+      log_line "WARNING: Instance #{instance.name} has no private IP, falling back to public IP", log_prefix: "Instance #{instance.name}"
+    end
+
+    host_ip_address
+  end
+
+  private def tailscale_peer_online?(hostname : String) : Bool
+    status_output = `tailscale status --json 2>/dev/null`
+    return false unless $?.success?
+
+    json = JSON.parse(status_output)
+    json["Peer"].as_h.each do |_key, peer|
+      dns_name = peer["DNSName"]?.try &.as_s
+      next unless dns_name && dns_name.starts_with?(hostname)
+      return peer["Online"]?.try(&.as_bool) == true
+    end
+    false
+  rescue JSON::ParseException | TypeCastError
+    false
   end
 end

--- a/templates/cloud_init.yaml
+++ b/templates/cloud_init.yaml
@@ -12,6 +12,8 @@ write_files:
 
 {{ ssh_files }}
 
+{{ tailscale_files }}
+
 {{ init_files }}
 
 packages: [{{ packages_str }}]


### PR DESCRIPTION
## Summary

This PR adds optional Tailscale support for administrative access to hetzner-k3s clusters.

When enabled, hetzner-k3s installs Tailscale on each node during provisioning, joins the nodes to the tailnet, uses Tailscale hostnames for SSH operations, and generates kubeconfig files that target the Kubernetes API over Tailscale.

This allows operators to keep SSH and Kubernetes API access on the tailnet instead of depending on public allowlists.

This is intentionally scoped to administrative access. It does not attempt to cover the broader IPv6-only / 464XLAT work discussed in #768.

## Changes

- add `networking.tailscale` configuration with `enabled`, `hostname_suffix`, and `auth_key`
- install and join Tailscale during cloud-init
- route hetzner-k3s SSH operations through Tailscale hostnames when enabled
- add Tailscale hostnames to the API server TLS SANs
- generate kubeconfig files that use the master's Tailscale hostname
- skip current-IP validation for `allowed_networks` when Tailscale is enabled
- document setup and cleanup requirements

## Notes

- existing behavior is unchanged when Tailscale is disabled
- cluster deletion does not remove machines from the tailnet; stale machines should be removed manually to avoid hostname suffix changes when recreating a cluster